### PR TITLE
feat: support external YOLO training data with improved logging and training pipeline

### DIFF
--- a/octron/_logging.py
+++ b/octron/_logging.py
@@ -7,9 +7,30 @@ The CLI branch can pass `debug=True` to enable DEBUG-level output.
 """
 
 import sys
+import logging
+import warnings
 from loguru import logger
 
 from octron._version import version as octron_version
+
+
+class _InterceptHandler(logging.Handler):
+    """Route standard-library logging records through loguru."""
+
+    def emit(self, record: logging.LogRecord) -> None:
+        # Map stdlib level → loguru level name
+        try:
+            level = logger.level(record.levelname).name
+        except ValueError:
+            level = record.levelno
+
+        # Walk the call stack to find the frame that called logger.warning() etc.
+        frame, depth = sys._getframe(6), 6
+        while frame and frame.f_code.co_filename == logging.__file__:
+            frame = frame.f_back
+            depth += 1
+
+        logger.opt(depth=depth, exception=record.exc_info).log(level, record.getMessage())
 
 
 _LOG_FORMAT_NORMAL = (
@@ -34,6 +55,8 @@ def setup_logging(debug: bool = False) -> None:
     debug:
         When True, set log level to DEBUG and include source location in every
         message.  When False (default), use INFO level with a compact format.
+        In non-debug mode, known noisy third-party warnings (pydantic,
+        torch pin_memory, torch.jit) are suppressed.
 
     This function is idempotent — calling it multiple times simply resets the
     handler to the current settings.
@@ -51,7 +74,25 @@ def setup_logging(debug: bool = False) -> None:
         enqueue=False,
     )
 
-    if debug:
+    # Route Python warnings and stdlib logging through loguru so all output
+    # passes through a single, consistently-formatted channel.
+    logging.captureWarnings(True)
+    logging.root.handlers = [_InterceptHandler()]
+    logging.root.setLevel(logging.DEBUG if debug else logging.WARNING)
+
+    if not debug:
+        # Suppress known noisy third-party DeprecationWarnings that are not
+        # actionable by OCTRON users:
+        #   • pydantic v1 json_encoders: fired at import time, not our code
+        #   • torch pin_memory: PyTorch 2.10 bug, fires every DataLoader batch
+        #   • torch.jit.trace: AMP initialisation noise at training startup
+        warnings.filterwarnings("ignore", message=".*json_encoders.*", category=DeprecationWarning)
+        warnings.filterwarnings("ignore", message=".*pin_memory.*", category=DeprecationWarning)
+        warnings.filterwarnings("ignore", category=UserWarning, module=r"torch\.jit")
+        warnings.filterwarnings("ignore", message=".*torch\.jit\.trace.*", category=DeprecationWarning)
+    else:
+        # In debug mode, restore default warning behaviour so everything shows.
+        warnings.resetwarnings()
         logger.debug("Debug logging enabled")
 
 

--- a/octron/_logging.py
+++ b/octron/_logging.py
@@ -8,6 +8,7 @@ The CLI branch can pass `debug=True` to enable DEBUG-level output.
 
 import sys
 import logging
+import warnings
 from loguru import logger
 
 from octron._version import version as octron_version
@@ -35,12 +36,19 @@ class _InterceptHandler(logging.Handler):
 # Substrings found in known-noisy third-party WARNING messages that should be
 # hidden in normal (non-debug) operation.
 _SUPPRESSED_WARNING_SUBSTRINGS = (
-    "json_encoders",        # pydantic v2 deprecation at napari import time
-    "argument 'device'",    # torch pin_memory() / is_pinned() — PyTorch 2.10 bug
-    "torch.jit.trace",      # torch.jit.trace / trace_method DeprecationWarning
-    "trace to be incorrect",  # TracerWarning fired during AMP initialisation
-    "already a ScriptModule",  # torch.jit UserWarning during AMP initialisation
+    "json_encoders",              # pydantic v2 deprecation at napari import time
+    "argument 'device'",          # torch pin_memory() / is_pinned() — PyTorch 2.10 bug
+    "torch.jit.trace",            # torch.jit.trace / trace_method DeprecationWarning
+    "trace to be incorrect",      # TracerWarning fired during AMP initialisation
+    "already a ScriptModule",     # torch.jit UserWarning during AMP initialisation
+    "'rect=True' is incompatible",  # ultralytics dataloader shuffle warning (expected)
 )
+
+# Suppress the pydantic json_encoders DeprecationWarning at import time so it
+# is filtered before any loguru handler (including any installed by ultralytics)
+# can print it.  This fires when napari (imported by yolo_octron.py) loads
+# pydantic — before we have a chance to evict ultralytics' loguru handler.
+warnings.filterwarnings("ignore", message=r".*json_encoders.*")
 
 
 def _make_loguru_filter(debug: bool):
@@ -132,6 +140,27 @@ def setup_logging(debug: bool = False) -> None:
     # Non-debug: only forward WARNING+ from stdlib logging to avoid paying the
     # cost of filtering high-volume ultralytics INFO records in _InterceptHandler.
     logging.root.setLevel(logging.DEBUG if debug else logging.WARNING)
+
+    # Tame the ultralytics Python logger.  ultralytics installs a StreamHandler
+    # directly on logging.getLogger('ultralytics') that prints architecture
+    # tables, config dumps, TensorBoard URLs, etc. straight to stdout — bypassing
+    # loguru entirely.  We remove those handlers and set the level so that:
+    #   • non-debug: only WARNING+ propagates (via root) to our InterceptHandler
+    #   • debug: everything propagates
+    # tqdm epoch-progress bars are written directly to stderr by tqdm and are
+    # unaffected by this change.
+    try:
+        _ult_logger = logging.getLogger("ultralytics")
+        for _h in _ult_logger.handlers[:]:
+            _ult_logger.removeHandler(_h)
+        _ult_logger.setLevel(logging.DEBUG if debug else logging.WARNING)
+        _ult_logger.propagate = True
+    except Exception:
+        pass  # ultralytics not yet imported — nothing to tame
+
+    # Re-apply the pydantic filter in case it was cleared by a third party.
+    if not debug:
+        warnings.filterwarnings("ignore", message=r".*json_encoders.*")
 
     if debug:
         logger.debug("Debug logging enabled")

--- a/octron/_logging.py
+++ b/octron/_logging.py
@@ -33,17 +33,27 @@ class _InterceptHandler(logging.Handler):
         logger.opt(depth=depth, exception=record.exc_info).log(level, record.getMessage())
 
 
-# Substrings found in known-noisy third-party WARNING messages.
-# These are suppressed in BOTH normal and debug mode: they are per-frame or
-# import-time side effects from third-party bugs and are never actionable.
-_SUPPRESSED_WARNING_SUBSTRINGS = (
+# Substrings found in third-party WARNING messages that are completely silent
+# (never shown, even on first occurrence).  These are per-frame or import-time
+# side effects that are never actionable and would flood the terminal.
+_ALWAYS_SUPPRESSED_SUBSTRINGS = (
     "json_encoders",              # pydantic v2 deprecation at napari import time
-    "argument 'device'",          # torch pin_memory() / is_pinned() — PyTorch 2.10 bug
-    "torch.jit.trace",            # torch.jit.trace / trace_method DeprecationWarning
     "trace to be incorrect",      # TracerWarning fired during AMP initialisation
     "already a ScriptModule",     # torch.jit UserWarning during AMP initialisation
     "'rect=True' is incompatible",  # ultralytics dataloader shuffle warning (expected)
 )
+
+# Substrings found in third-party WARNING messages that are shown only once
+# per session (first occurrence passes through; subsequent repeats are dropped).
+_SHOW_ONCE_SUBSTRINGS = (
+    "argument 'device'",          # torch pin_memory() / is_pinned() — PyTorch 2.10 bug
+    "torch.jit.trace",            # torch.jit.trace / trace_method DeprecationWarning
+)
+
+# Session-level set of warning message keys already shown once.
+# Keyed on the first 200 characters of the message to deduplicate repeats
+# across DataLoader thread restarts (where Python's __warningregistry__ resets).
+_shown_warnings: set = set()
 
 # Python logger name prefixes whose DEBUG/INFO records are always suppressed,
 # even in --debug mode.  These libraries produce high-volume messages that are
@@ -64,9 +74,10 @@ def _make_loguru_filter(debug: bool):
     """Return a loguru filter callable for the given verbosity mode.
 
     Both modes suppress:
-    - Known per-frame / import-time WARNING noise (pin_memory, TracerWarning,
-      pydantic json_encoders, …) — these fire thousands of times and are not
-      actionable; hiding them even in debug keeps progress bars readable.
+    - Known per-frame / import-time WARNING noise (TracerWarning, pydantic
+      json_encoders, …) — always silent because they fire thousands of times.
+    - Known per-epoch WARNING noise (pin_memory, torch.jit.trace) — shown once
+      per session, then suppressed on subsequent repetitions.
     - DEBUG/INFO from high-volume library loggers (matplotlib, PIL) — unrelated
       to octron and would break ``\\r\\033[K`` in-place progress-bar display.
 
@@ -75,17 +86,27 @@ def _make_loguru_filter(debug: bool):
     - Blocks all other INFO/DEBUG — suppresses the ultralytics architecture
       table, training-config dump, TensorBoard URL, scan progress bars, etc.
     """
-    substrings = _SUPPRESSED_WARNING_SUBSTRINGS
+    always_suppress = _ALWAYS_SUPPRESSED_SUBSTRINGS
+    show_once = _SHOW_ONCE_SUBSTRINGS
     noisy_prefixes = _NOISY_LIBRARY_PREFIXES
 
     def _filter(record) -> bool:
         level_no = record["level"].no
         name = record["name"]
+        message = record["message"]
 
-        # Always suppress per-frame WARNING noise (both normal and debug mode).
         if level_no == 30:  # WARNING
-            if any(s in record["message"] for s in substrings):
+            # Always-silent substrings — never shown.
+            if any(s in message for s in always_suppress):
                 return False
+
+            # Show-once substrings — first occurrence passes, repeats dropped.
+            if any(s in message for s in show_once):
+                key = message[:200]
+                if key in _shown_warnings:
+                    return False
+                _shown_warnings.add(key)
+                # fall through to show the first occurrence
 
         # Always suppress high-volume library debug spam that breaks progress bars.
         if level_no < 30 and any(name.startswith(p) for p in noisy_prefixes):

--- a/octron/_logging.py
+++ b/octron/_logging.py
@@ -33,8 +33,9 @@ class _InterceptHandler(logging.Handler):
         logger.opt(depth=depth, exception=record.exc_info).log(level, record.getMessage())
 
 
-# Substrings found in known-noisy third-party WARNING messages that should be
-# hidden in normal (non-debug) operation.
+# Substrings found in known-noisy third-party WARNING messages.
+# These are suppressed in BOTH normal and debug mode: they are per-frame or
+# import-time side effects from third-party bugs and are never actionable.
 _SUPPRESSED_WARNING_SUBSTRINGS = (
     "json_encoders",              # pydantic v2 deprecation at napari import time
     "argument 'device'",          # torch pin_memory() / is_pinned() — PyTorch 2.10 bug
@@ -42,6 +43,14 @@ _SUPPRESSED_WARNING_SUBSTRINGS = (
     "trace to be incorrect",      # TracerWarning fired during AMP initialisation
     "already a ScriptModule",     # torch.jit UserWarning during AMP initialisation
     "'rect=True' is incompatible",  # ultralytics dataloader shuffle warning (expected)
+)
+
+# Python logger name prefixes whose DEBUG/INFO records are always suppressed,
+# even in --debug mode.  These libraries produce high-volume messages that are
+# unrelated to octron behaviour and break in-place progress-bar display.
+_NOISY_LIBRARY_PREFIXES = (
+    "matplotlib",
+    "PIL",
 )
 
 # Suppress the pydantic json_encoders DeprecationWarning at import time so it
@@ -54,33 +63,43 @@ warnings.filterwarnings("ignore", message=r".*json_encoders.*")
 def _make_loguru_filter(debug: bool):
     """Return a loguru filter callable for the given verbosity mode.
 
-    In non-debug mode the filter:
-    - Passes any record from an ``octron.*`` module at INFO and above.
-    - Passes non-octron WARNING records unless they match a known-noisy pattern
-      (pydantic, torch pin_memory, torch.jit TracerWarning, …).
-    - Blocks everything else — in particular ultralytics INFO output such as
-      the model architecture table, training-config dump, TensorBoard URL, and
-      dataset scan progress bars.
+    Both modes suppress:
+    - Known per-frame / import-time WARNING noise (pin_memory, TracerWarning,
+      pydantic json_encoders, …) — these fire thousands of times and are not
+      actionable; hiding them even in debug keeps progress bars readable.
+    - DEBUG/INFO from high-volume library loggers (matplotlib, PIL) — unrelated
+      to octron and would break ``\\r\\033[K`` in-place progress-bar display.
 
-    In debug mode ``None`` is returned (loguru skips filtering entirely).
+    Non-debug mode additionally:
+    - Only passes octron.* records at INFO and above.
+    - Blocks all other INFO/DEBUG — suppresses the ultralytics architecture
+      table, training-config dump, TensorBoard URL, scan progress bars, etc.
     """
-    if debug:
-        return None
-
     substrings = _SUPPRESSED_WARNING_SUBSTRINGS
+    noisy_prefixes = _NOISY_LIBRARY_PREFIXES
 
     def _filter(record) -> bool:
         level_no = record["level"].no
-        # Always pass octron messages at INFO and above
-        if record["name"].startswith("octron") or record["name"] == "__main__":
+        name = record["name"]
+
+        # Always suppress per-frame WARNING noise (both normal and debug mode).
+        if level_no == 30:  # WARNING
+            if any(s in record["message"] for s in substrings):
+                return False
+
+        # Always suppress high-volume library debug spam that breaks progress bars.
+        if level_no < 30 and any(name.startswith(p) for p in noisy_prefixes):
+            return False
+
+        if debug:
+            # Show everything else in debug mode.
+            return True
+
+        # Non-debug: pass octron messages at INFO and above.
+        if name.startswith("octron") or name == "__main__":
             return level_no >= 20  # INFO = 20
-        # Non-octron WARNING: pass unless it matches a suppressed pattern
-        if level_no >= 30:  # WARNING = 30
-            msg = record["message"]
-            return not any(s in msg for s in substrings)
-        # Non-octron INFO and below: suppress
-        # (covers ultralytics architecture table, config dump, TensorBoard URL, …)
-        return False
+        # Non-octron WARNING+ that wasn't suppressed above.
+        return level_no >= 30
 
     return _filter
 

--- a/octron/_logging.py
+++ b/octron/_logging.py
@@ -8,7 +8,6 @@ The CLI branch can pass `debug=True` to enable DEBUG-level output.
 
 import sys
 import logging
-import warnings
 from loguru import logger
 
 from octron._version import version as octron_version
@@ -33,6 +32,51 @@ class _InterceptHandler(logging.Handler):
         logger.opt(depth=depth, exception=record.exc_info).log(level, record.getMessage())
 
 
+# Substrings found in known-noisy third-party WARNING messages that should be
+# hidden in normal (non-debug) operation.
+_SUPPRESSED_WARNING_SUBSTRINGS = (
+    "json_encoders",        # pydantic v2 deprecation at napari import time
+    "argument 'device'",    # torch pin_memory() / is_pinned() — PyTorch 2.10 bug
+    "torch.jit.trace",      # torch.jit.trace / trace_method DeprecationWarning
+    "trace to be incorrect",  # TracerWarning fired during AMP initialisation
+    "already a ScriptModule",  # torch.jit UserWarning during AMP initialisation
+)
+
+
+def _make_loguru_filter(debug: bool):
+    """Return a loguru filter callable for the given verbosity mode.
+
+    In non-debug mode the filter:
+    - Passes any record from an ``octron.*`` module at INFO and above.
+    - Passes non-octron WARNING records unless they match a known-noisy pattern
+      (pydantic, torch pin_memory, torch.jit TracerWarning, …).
+    - Blocks everything else — in particular ultralytics INFO output such as
+      the model architecture table, training-config dump, TensorBoard URL, and
+      dataset scan progress bars.
+
+    In debug mode ``None`` is returned (loguru skips filtering entirely).
+    """
+    if debug:
+        return None
+
+    substrings = _SUPPRESSED_WARNING_SUBSTRINGS
+
+    def _filter(record) -> bool:
+        level_no = record["level"].no
+        # Always pass octron messages at INFO and above
+        if record["name"].startswith("octron") or record["name"] == "__main__":
+            return level_no >= 20  # INFO = 20
+        # Non-octron WARNING: pass unless it matches a suppressed pattern
+        if level_no >= 30:  # WARNING = 30
+            msg = record["message"]
+            return not any(s in msg for s in substrings)
+        # Non-octron INFO and below: suppress
+        # (covers ultralytics architecture table, config dump, TensorBoard URL, …)
+        return False
+
+    return _filter
+
+
 _LOG_FORMAT_NORMAL = (
     "<cyan>{time:HH:mm:ss}</cyan> | "
     "<level>{level: <8}</level> | "
@@ -55,13 +99,19 @@ def setup_logging(debug: bool = False) -> None:
     debug:
         When True, set log level to DEBUG and include source location in every
         message.  When False (default), use INFO level with a compact format.
-        In non-debug mode, known noisy third-party warnings (pydantic,
-        torch pin_memory, torch.jit) are suppressed.
+
+        In non-debug mode a loguru filter is applied that:
+        - Passes octron.* records at INFO and above (our own progress messages).
+        - Passes non-octron WARNING records that are not known third-party noise
+          (pydantic, torch pin_memory, torch.jit TracerWarning, …).
+        - Blocks non-octron INFO, suppressing the ultralytics architecture table,
+          training-config parameter dump, TensorBoard URL, and scan bars.
 
     This function is idempotent — calling it multiple times simply resets the
-    handler to the current settings.
+    handler to the current settings.  Call it again after ultralytics has been
+    imported to evict any loguru handler ultralytics may have installed.
     """
-    logger.remove()  # drop default stderr handler
+    logger.remove()  # remove ALL handlers, including any installed by ultralytics
 
     level = "DEBUG" if debug else "INFO"
     fmt = _LOG_FORMAT_DEBUG if debug else _LOG_FORMAT_NORMAL
@@ -71,6 +121,7 @@ def setup_logging(debug: bool = False) -> None:
         level=level,
         format=fmt,
         colorize=True,
+        filter=_make_loguru_filter(debug),
         enqueue=False,
     )
 
@@ -78,21 +129,11 @@ def setup_logging(debug: bool = False) -> None:
     # passes through a single, consistently-formatted channel.
     logging.captureWarnings(True)
     logging.root.handlers = [_InterceptHandler()]
+    # Non-debug: only forward WARNING+ from stdlib logging to avoid paying the
+    # cost of filtering high-volume ultralytics INFO records in _InterceptHandler.
     logging.root.setLevel(logging.DEBUG if debug else logging.WARNING)
 
-    if not debug:
-        # Suppress known noisy third-party DeprecationWarnings that are not
-        # actionable by OCTRON users:
-        #   • pydantic v1 json_encoders: fired at import time, not our code
-        #   • torch pin_memory: PyTorch 2.10 bug, fires every DataLoader batch
-        #   • torch.jit.trace: AMP initialisation noise at training startup
-        warnings.filterwarnings("ignore", message=".*json_encoders.*", category=DeprecationWarning)
-        warnings.filterwarnings("ignore", message=".*pin_memory.*", category=DeprecationWarning)
-        warnings.filterwarnings("ignore", category=UserWarning, module=r"torch\.jit")
-        warnings.filterwarnings("ignore", message=".*torch\.jit\.trace.*", category=DeprecationWarning)
-    else:
-        # In debug mode, restore default warning behaviour so everything shows.
-        warnings.resetwarnings()
+    if debug:
         logger.debug("Debug logging enabled")
 
 

--- a/octron/cli.py
+++ b/octron/cli.py
@@ -113,27 +113,61 @@ def split(
 
 @app.command()
 def train(
-    project_path: Path = typer.Argument(..., help="Path to the OCTRON project directory."),
+    project_path: Optional[Path] = typer.Argument(None, help="Path to the OCTRON project directory. Optional when --data-dir is provided."),
     model: YOLOModel = typer.Option(YOLOModel.yolo26m, help="YOLO model to train."),
-    train_mode: TrainMode = typer.Option(TrainMode.segment, "--mode", help="Training mode."),
+    train_mode: Optional[TrainMode] = typer.Option(None, "--mode", help="Training mode (segment or detect). When --data-dir is used, defaults to the value in yolo_config.yaml."),
     device: Device = typer.Option(Device.auto, help="Device to train on."),
     epochs: int = typer.Option(250, help="Number of training epochs."),
     imagesz: int = typer.Option(640, help="Input image size."),
     save_period: int = typer.Option(50, help="Save a checkpoint every N epochs."),
     overwrite: bool = typer.Option(False, "--overwrite", help="Overwrite an existing trained model. Default: skip if best.pt already exists."),
-    resume: bool = typer.Option(False, help="Resume from an existing last.pt checkpoint."),
+    resume: bool = typer.Option(False, help="Resume from an existing last.pt checkpoint. Use --run-name to target a specific previous run."),
     no_split: bool = typer.Option(False, "--no-split", help="Skip data preparation. Use when 'octron split' has already been run."),
-    train_fraction: float = typer.Option(0.7, "--train", help="Fraction of frames for training (ignored with --no-split)."),
-    val_fraction: float = typer.Option(0.15, "--val", help="Fraction of frames for validation (ignored with --no-split)."),
-    seed: int = typer.Option(88, "--seed", help="Random seed for the split (ignored with --no-split)."),
+    train_fraction: float = typer.Option(0.7, "--train", help="Fraction of frames for training (ignored with --no-split or --data-dir)."),
+    val_fraction: float = typer.Option(0.15, "--val", help="Fraction of frames for validation (ignored with --no-split or --data-dir)."),
+    seed: int = typer.Option(88, "--seed", help="Random seed for the split (ignored with --no-split or --data-dir)."),
+    data_dir: Optional[Path] = typer.Option(None, "--data-dir", help="Path to an external YOLO training data directory containing yolo_config.yaml and train/val splits. Skips OCTRON data preparation."),
+    output_dir: Optional[Path] = typer.Option(None, "--output-dir", "-o", help="Base directory for training output. Defaults to <project>/model/ or <data-dir>/model/."),
+    run_name: Optional[str] = typer.Option(None, "--run-name", help="Name for this training run (subfolder inside output dir). Defaults to an auto-generated name encoding model, mode, image size, and date."),
 ):
-    """Prepare training data and run YOLO model training on an OCTRON project."""
+    """Train a YOLO model on an OCTRON project or external YOLO-format data.
+
+    Either project_path or --data-dir must be provided.
+
+    With --data-dir, training data is used as-is (OCTRON annotation pipeline
+    is skipped). The directory must contain a yolo_config.yaml file and
+    train/val subdirectories with image and label files.
+    """
     from octron.tools.train import run_training
+    from datetime import date
+
+    if project_path is None and data_dir is None:
+        raise typer.BadParameter(
+            "Either project_path or --data-dir must be provided.",
+            param_hint="project_path / --data-dir",
+        )
+
+    # Resolve train_mode: when --data-dir is used and --mode is not specified,
+    # run_training() will read it from yolo_config.yaml. For OCTRON projects
+    # without --mode, default to segment.
+    resolved_mode = train_mode
+    if resolved_mode is None and data_dir is None:
+        resolved_mode = TrainMode.segment
+
+    # Auto-generate an informative run name for CLI runs
+    if run_name is None:
+        model_slug = model.value.lower()
+        mode_slug = "seg" if (resolved_mode is None or resolved_mode == TrainMode.segment) else "det"
+        today = date.today().strftime("%Y%m%d")
+        run_name = f"{model_slug}_{mode_slug}_{imagesz}_{today}"
 
     run_training(
         project_path=project_path,
+        data_dir=data_dir,
+        output_dir=output_dir,
+        run_name=run_name,
         model=model,
-        train_mode=train_mode,
+        train_mode=resolved_mode,
         device=device,
         epochs=epochs,
         imagesz=imagesz,

--- a/octron/cli.py
+++ b/octron/cli.py
@@ -134,6 +134,8 @@ def train(
     train_fraction: float = typer.Option(0.7, "--train", help="Fraction of frames for training (ignored with --no-split or --data-dir)."),
     val_fraction: float = typer.Option(0.15, "--val", help="Fraction of frames for validation (ignored with --no-split or --data-dir)."),
     seed: int = typer.Option(88, "--seed", help="Random seed for the split (ignored with --no-split or --data-dir)."),
+    # --- Verbosity ---
+    debug: bool = typer.Option(False, "--debug", help="Show full ultralytics output, architecture table, and all warnings. By default training output is condensed."),
 ):
     """Train a YOLO model on an OCTRON project or external YOLO-format data.
 
@@ -144,7 +146,11 @@ def train(
     train/val subdirectories with image and label files.
     """
     from octron.tools.train import run_training
+    from octron._logging import setup_logging
     from datetime import date
+
+    # Re-initialise logging so --debug takes effect before any imports fire
+    setup_logging(debug=debug)
 
     if project_path is None and data_dir is None:
         raise typer.BadParameter(
@@ -183,6 +189,7 @@ def train(
         train_fraction=train_fraction,
         val_fraction=val_fraction,
         seed=seed,
+        debug=debug,
     )
 
 

--- a/octron/cli.py
+++ b/octron/cli.py
@@ -136,6 +136,8 @@ def train(
     seed: int = typer.Option(88, "--seed", help="Random seed for the split (ignored with --no-split or --data-dir)."),
     # --- Verbosity ---
     debug: bool = typer.Option(False, "--debug", help="Show full ultralytics output, architecture table, and all warnings. By default training output is condensed."),
+    # --- Batch size ---
+    batch_size: Optional[int] = typer.Option(None, "--batch-size", help="Training batch size. Defaults to -1 (ultralytics AutoBatch: probes VRAM on the target device to find the largest safe batch)."),
 ):
     """Train a YOLO model on an OCTRON project or external YOLO-format data.
 
@@ -190,6 +192,7 @@ def train(
         val_fraction=val_fraction,
         seed=seed,
         debug=debug,
+        batch_size=batch_size if batch_size is not None else -1,
     )
 
 

--- a/octron/cli.py
+++ b/octron/cli.py
@@ -123,6 +123,7 @@ def train(
     epochs: int = typer.Option(250, help="Number of training epochs."),
     imagesz: int = typer.Option(640, help="Input image size."),
     device: Device = typer.Option(Device.auto, help="Device to train on."),
+    batch_size: Optional[int] = typer.Option(None, "--batch-size", help="Training batch size. Defaults to -1 (ultralytics AutoBatch: probes VRAM on the target device to find the largest safe batch)."),
     save_period: int = typer.Option(50, help="Save a checkpoint every N epochs."),
     # --- Output control ---
     output_dir: Optional[Path] = typer.Option(None, "--output-dir", "-o", help="Base directory for training output. Defaults to <project>/model/ or <data-dir>/model/."),
@@ -136,8 +137,6 @@ def train(
     seed: int = typer.Option(88, "--seed", help="Random seed for the split (ignored with --no-split or --data-dir)."),
     # --- Verbosity ---
     debug: bool = typer.Option(False, "--debug", help="Show full ultralytics output, architecture table, and all warnings. By default training output is condensed."),
-    # --- Batch size ---
-    batch_size: Optional[int] = typer.Option(None, "--batch-size", help="Training batch size. Defaults to -1 (ultralytics AutoBatch: probes VRAM on the target device to find the largest safe batch)."),
 ):
     """Train a YOLO model on an OCTRON project or external YOLO-format data.
 

--- a/octron/cli.py
+++ b/octron/cli.py
@@ -113,22 +113,27 @@ def split(
 
 @app.command()
 def train(
+    # --- Data source ---
     project_path: Optional[Path] = typer.Argument(None, help="Path to the OCTRON project directory. Optional when --data-dir is provided."),
+    data_dir: Optional[Path] = typer.Option(None, "--data-dir", help="Path to an external YOLO training data directory containing yolo_config.yaml and train/val splits. Skips OCTRON data preparation."),
+    # --- Model ---
     model: YOLOModel = typer.Option(YOLOModel.yolo26m, help="YOLO model to train."),
     train_mode: Optional[TrainMode] = typer.Option(None, "--mode", help="Training mode (segment or detect). When --data-dir is used, defaults to the value in yolo_config.yaml."),
-    device: Device = typer.Option(Device.auto, help="Device to train on."),
+    # --- Core hyperparameters ---
     epochs: int = typer.Option(250, help="Number of training epochs."),
     imagesz: int = typer.Option(640, help="Input image size."),
+    device: Device = typer.Option(Device.auto, help="Device to train on."),
     save_period: int = typer.Option(50, help="Save a checkpoint every N epochs."),
+    # --- Output control ---
+    output_dir: Optional[Path] = typer.Option(None, "--output-dir", "-o", help="Base directory for training output. Defaults to <project>/model/ or <data-dir>/model/."),
+    run_name: Optional[str] = typer.Option(None, "--run-name", help="Name for this training run (subfolder inside output dir). Defaults to an auto-generated name encoding model, mode, image size, and date."),
     overwrite: bool = typer.Option(False, "--overwrite", help="Overwrite an existing trained model. Default: skip if best.pt already exists."),
     resume: bool = typer.Option(False, help="Resume from an existing last.pt checkpoint. Use --run-name to target a specific previous run."),
+    # --- Data split (OCTRON projects only) ---
     no_split: bool = typer.Option(False, "--no-split", help="Skip data preparation. Use when 'octron split' has already been run."),
     train_fraction: float = typer.Option(0.7, "--train", help="Fraction of frames for training (ignored with --no-split or --data-dir)."),
     val_fraction: float = typer.Option(0.15, "--val", help="Fraction of frames for validation (ignored with --no-split or --data-dir)."),
     seed: int = typer.Option(88, "--seed", help="Random seed for the split (ignored with --no-split or --data-dir)."),
-    data_dir: Optional[Path] = typer.Option(None, "--data-dir", help="Path to an external YOLO training data directory containing yolo_config.yaml and train/val splits. Skips OCTRON data preparation."),
-    output_dir: Optional[Path] = typer.Option(None, "--output-dir", "-o", help="Base directory for training output. Defaults to <project>/model/ or <data-dir>/model/."),
-    run_name: Optional[str] = typer.Option(None, "--run-name", help="Name for this training run (subfolder inside output dir). Defaults to an auto-generated name encoding model, mode, image size, and date."),
 ):
     """Train a YOLO model on an OCTRON project or external YOLO-format data.
 

--- a/octron/tools/split.py
+++ b/octron/tools/split.py
@@ -6,9 +6,65 @@ running model training.  The `octron train` command calls this internally;
 users can also run it standalone via `octron split`.
 """
 
+import time
 from pathlib import Path
 
 _MODELS_YAML = Path(__file__).parent.parent / "yolo_octron" / "yolo_models.yaml"
+_PRINT_INTERVAL = 0.1  # seconds between progress line rewrites
+
+
+def _run_progress(heading, gen, fmt):
+    """
+    Consume a progress-yielding generator and display a single updating line,
+    matching the style used in ``octron predict``.
+
+    Parameters
+    ----------
+    heading : str
+        Text printed on its own line before the progress starts.
+    gen : iterable
+        For ``fmt='polygons'``: yields ``(no_entry, total, label, frame_no, total_frames)``.
+        For ``fmt='export'``:   yields ``(no_entry, total, label, split, frame_no, total_frames)``.
+    fmt : str
+        ``'polygons'`` or ``'export'``.
+    """
+    print(heading + "...")
+    _last_t = 0.0
+    _line_open = False
+    _last_label = None
+
+    for item in gen:
+        if fmt == "polygons":
+            no_entry, total, label, frame_no, total_frames = item
+            split_tag = ""
+        else:
+            no_entry, total, label, split, frame_no, total_frames = item
+            split_tag = f" ({split})"
+
+        # Print a fresh line whenever the label changes so completed labels
+        # stay visible in the scroll buffer.
+        if label != _last_label:
+            if _line_open:
+                print()
+            _last_label = label
+            _line_open = False
+
+        now = time.monotonic()
+        if now - _last_t < _PRINT_INTERVAL and frame_no != total_frames:
+            continue
+
+        pct = 100.0 * frame_no / total_frames if total_frames > 0 else 0.0
+        print(
+            f"\r\033[K  [{no_entry}/{total}] {label}{split_tag}: "
+            f"{frame_no}/{total_frames} frames  {pct:.0f}%",
+            end="",
+            flush=True,
+        )
+        _line_open = True
+        _last_t = now
+
+    if _line_open:
+        print()
 
 
 def run_split(
@@ -61,22 +117,9 @@ def run_split(
     yolo.prepare_labels()
 
     # --- Step 2: generate polygons / bboxes ---
-    if train_mode == "segment":
-        print("Generating polygons...")
-        for no_entry, total, label, frame_no, total_frames in yolo.prepare_polygons():
-            print(
-                f"  [{no_entry}/{total}] {label}: frame {frame_no}/{total_frames}",
-                end="\r",
-            )
-        print()
-    else:
-        print("Generating bounding boxes...")
-        for no_entry, total, label, frame_no, total_frames in yolo.prepare_bboxes():
-            print(
-                f"  [{no_entry}/{total}] {label}: frame {frame_no}/{total_frames}",
-                end="\r",
-            )
-        print()
+    verb = "Generating polygons" if train_mode == "segment" else "Generating bounding boxes"
+    gen2 = yolo.prepare_polygons() if train_mode == "segment" else yolo.prepare_bboxes()
+    _run_progress(verb, gen2, fmt="polygons")
 
     # --- Step 3: split ---
     print("Splitting data into train/val/test sets...")
@@ -93,17 +136,8 @@ def run_split(
         return
 
     # --- Step 4: export to disk ---
-    print("Exporting training data...")
-    if train_mode == "segment":
-        gen = yolo.create_training_data_segment()
-    else:
-        gen = yolo.create_training_data_detect()
-    for no_entry, total, label, split, frame_no, total_frames in gen:
-        print(
-            f"  [{no_entry}/{total}] {label} ({split}): frame {frame_no}/{total_frames}",
-            end="\r",
-        )
-    print()
+    gen4 = yolo.create_training_data_segment() if train_mode == "segment" else yolo.create_training_data_detect()
+    _run_progress("Exporting training data", gen4, fmt="export")
 
     yolo.write_yolo_config(train_mode=train_mode)
     print("Training data export complete.")

--- a/octron/tools/train.py
+++ b/octron/tools/train.py
@@ -4,10 +4,15 @@ OCTRON training pipeline.
 Wraps the YOLO_octron model-loading and training steps into a single callable.
 By default, training data is prepared automatically via ``run_split()``.
 Pass ``skip_split=True`` if ``octron split`` has already been run.
+
+External training data (not from an OCTRON project) can be used by passing
+``data_dir`` pointing to a directory that contains a valid ``yolo_config.yaml``
+together with the standard YOLO train/val/test split subdirectories.
 """
 
 import json
 from pathlib import Path
+from typing import Optional
 
 _MODELS_YAML = Path(__file__).parent.parent / "yolo_octron" / "yolo_models.yaml"
 
@@ -64,10 +69,70 @@ def _normalise_model_name(model, models_yaml_path):
     return match if match is not None else model_str
 
 
+def _validate_data_dir(data_dir: Path):
+    """
+    Validate that *data_dir* contains a complete YOLO training dataset.
+
+    Checks performed:
+    - ``yolo_config.yaml`` exists and is parseable
+    - Required fields ``names``, ``train``, and ``val`` are present
+    - Train and val subdirectories exist
+    - At least one label file (.txt) is present in the train split
+
+    Returns
+    -------
+    cfg : dict
+        Parsed contents of ``yolo_config.yaml``.
+    train_mode : str or None
+        Value of ``train_mode`` from the yaml, or ``None`` if not present.
+    """
+    import yaml
+
+    config_path = data_dir / "yolo_config.yaml"
+    if not config_path.exists():
+        raise FileNotFoundError(
+            f"No yolo_config.yaml found in {data_dir}. "
+            "The data directory must contain a valid YOLO config file."
+        )
+
+    with open(config_path) as f:
+        cfg = yaml.safe_load(f)
+
+    for field in ("names", "train", "val"):
+        if field not in cfg:
+            raise ValueError(
+                f"yolo_config.yaml is missing required field '{field}'."
+            )
+
+    train_subdir = data_dir / cfg["train"]
+    val_subdir = data_dir / cfg["val"]
+
+    if not train_subdir.exists():
+        raise FileNotFoundError(
+            f"Training split directory not found: {train_subdir}"
+        )
+    if not val_subdir.exists():
+        raise FileNotFoundError(
+            f"Validation split directory not found: {val_subdir}"
+        )
+
+    label_files = list(train_subdir.glob("*.txt"))
+    if not label_files:
+        raise FileNotFoundError(
+            f"No label files (.txt) found in training split: {train_subdir}"
+        )
+
+    yaml_mode = cfg.get("train_mode")
+    return cfg, yaml_mode
+
+
 def run_training(
-    project_path,
+    project_path=None,
+    data_dir: Optional[Path] = None,
+    output_dir: Optional[Path] = None,
+    run_name: Optional[str] = None,
     model="YOLO26m",
-    train_mode="segment",
+    train_mode=None,
     device="auto",
     epochs=250,
     imagesz=640,
@@ -85,12 +150,30 @@ def run_training(
     By default this prepares and exports training data before training.
     Pass ``skip_split=True`` to skip that step when data is already up to date.
 
+    External training data (not from an OCTRON project) can be used by passing
+    ``data_dir`` pointing to a directory with a ``yolo_config.yaml`` file and
+    the corresponding YOLO split subdirectories.
+
     Parameters
     ----------
-    project_path : str or Path
-        Path to the OCTRON project directory.
+    project_path : str or Path, optional
+        Path to the OCTRON project directory. Required unless ``data_dir`` is given.
+    data_dir : Path, optional
+        Path to an external YOLO training data directory. When provided,
+        ``skip_split`` is implied and ``train_mode`` is read from
+        ``yolo_config.yaml`` if not explicitly supplied.
+    output_dir : Path, optional
+        Base directory where the training run folder will be created.
+        Defaults to ``<project_path>/model/`` or ``<data_dir>/model/``.
+    run_name : str, optional
+        Name of the training run subdirectory. When ``None`` the GUI default
+        ``'training'`` is used, preserving existing behaviour. CLI callers
+        should pass an informative name such as ``'yolo26m_seg_640_20260327'``.
     model : str or Path
         YOLO model name (e.g. 'YOLO11m') or path to an existing model file.
+    train_mode : str or None
+        'segment' or 'detect'. When ``None`` and ``data_dir`` is provided the
+        value is read from ``yolo_config.yaml``; falls back to 'segment'.
     device : str
         Device to train on ('auto', 'cpu', 'cuda', 'mps'). 'auto' selects
         CUDA if available, then MPS, then CPU.
@@ -100,8 +183,6 @@ def run_training(
         Input image size for training.
     save_period : int
         Save a checkpoint every N epochs.
-    train_mode : str
-        'segment' for instance segmentation, 'detect' for bounding-box detection.
     resume : bool
         Resume training from an existing last.pt checkpoint.
     skip_split : bool
@@ -118,13 +199,43 @@ def run_training(
     from octron.test_gpu import auto_device
     from octron.tools.split import run_split
 
-    # Unwrap enums to plain strings so they are never serialised as Python
-    # object tags when written into YAML config files downstream.
-    train_mode = train_mode.value if hasattr(train_mode, 'value') else str(train_mode)
+    # Unwrap enums to plain strings
     device = device.value if hasattr(device, 'value') else str(device)
+    if train_mode is not None:
+        train_mode = train_mode.value if hasattr(train_mode, 'value') else str(train_mode)
 
-    best_pt = Path(project_path) / "model" / "training" / "weights" / "best.pt"
-    last_pt = Path(project_path) / "model" / "training" / "weights" / "last.pt"
+    # --- Resolve paths and config based on data source ---
+    if data_dir is not None:
+        data_dir = Path(data_dir)
+        cfg, yaml_mode = _validate_data_dir(data_dir)
+        # Use yaml train_mode if caller didn't specify one explicitly
+        if train_mode is None:
+            train_mode = yaml_mode
+        config_path = data_dir / "yolo_config.yaml"
+        img_search_path = data_dir
+        output_base = Path(output_dir) if output_dir else data_dir / "model"
+        batch_cache = output_base / "autobatch_cache.json"
+        skip_split = True  # external data is already prepared
+    else:
+        if project_path is None:
+            raise ValueError("Either project_path or data_dir must be provided.")
+        project_path = Path(project_path)
+        config_path = project_path / "model" / "training_data" / "yolo_config.yaml"
+        img_search_path = project_path / "model" / "training_data"
+        output_base = Path(output_dir) if output_dir else project_path / "model"
+        batch_cache = project_path / "model" / "autobatch_cache.json"
+
+    # Default train_mode if still unresolved
+    if train_mode is None:
+        train_mode = "segment"
+
+    # Default run_name: GUI always passes 'training'; CLI passes an informative name
+    if run_name is None:
+        run_name = "training"
+
+    # --- Check for existing run ---
+    best_pt = output_base / run_name / "weights" / "best.pt"
+    last_pt = output_base / run_name / "weights" / "last.pt"
     if resume:
         if best_pt.exists():
             print(f"Training already completed ({best_pt}). Nothing to resume. Use --overwrite to retrain from scratch.")
@@ -139,7 +250,7 @@ def run_training(
     if device == "auto":
         device = auto_device()
 
-    # --- Steps 1–4: prepare and export training data ---
+    # --- Steps 1–4: prepare and export training data (OCTRON projects only) ---
     if not skip_split:
         run_split(
             project_path=project_path,
@@ -153,11 +264,13 @@ def run_training(
     # --- Step 5: load the base model (or last.pt when resuming) ---
     yolo = YOLO_octron(
         models_yaml_path=_MODELS_YAML,
-        project_path=project_path,
+        project_path=project_path if project_path is not None else output_base,
         clean_training_dir=False,
     )
     yolo.train_mode = train_mode
-    yolo.config_path = yolo.data_path / "yolo_config.yaml"
+    yolo.config_path = config_path
+    yolo.data_path = img_search_path
+    yolo.training_path = output_base
 
     if resume:
         print(f"Resuming from checkpoint: {last_pt}")
@@ -168,10 +281,11 @@ def run_training(
         yolo.load_model(model, train_mode=train_mode)
 
     # --- Step 6: train ---
-    batch_cache = Path(project_path) / "model" / "autobatch_cache.json"
     batch = _get_batch_size(yolo, imagesz, device, batch_cache)
 
     print(f"Training for {epochs} epochs on {device}...")
+    print(f"Run name: {run_name}")
+    print(f"Output:   {output_base / run_name}")
     for progress in yolo.train(
         device=device,
         imagesz=imagesz,
@@ -180,6 +294,7 @@ def run_training(
         train_mode=train_mode,
         resume=resume,
         batch=batch,
+        run_name=run_name,
     ):
         epoch = progress.get("epoch", "?")
         total_epochs = progress.get("total_epochs", "?")

--- a/octron/tools/train.py
+++ b/octron/tools/train.py
@@ -281,9 +281,14 @@ def run_training(
         )
 
     # --- Step 5: load the base model (or last.pt when resuming) ---
+    # When only --data-dir is provided, output_base (data_dir/model/) is used
+    # as the YOLO_octron project root. Create it if needed so the path-existence
+    # check in YOLO_octron's project_path setter doesn't raise.
+    yolo_project_path = project_path if project_path is not None else output_base
+    yolo_project_path.mkdir(parents=True, exist_ok=True)
     yolo = YOLO_octron(
         models_yaml_path=_MODELS_YAML,
-        project_path=project_path if project_path is not None else output_base,
+        project_path=yolo_project_path,
         clean_training_dir=False,
     )
     yolo.train_mode = train_mode

--- a/octron/tools/train.py
+++ b/octron/tools/train.py
@@ -12,18 +12,9 @@ together with the standard YOLO train/val/test split subdirectories.
 
 from pathlib import Path
 from typing import Optional
+from loguru import logger
 
 _MODELS_YAML = Path(__file__).parent.parent / "yolo_octron" / "yolo_models.yaml"
-
-
-def _get_batch_size(model, imgsz):
-    """Return the optimal batch size for training via ultralytics AutoBatch."""
-    from ultralytics.utils.autobatch import check_train_batch_size
-
-    print("AutoBatch: searching for optimal batch size...")
-    batch = check_train_batch_size(model.model.model, imgsz=imgsz, amp=True)
-    print(f"AutoBatch: using batch size {batch}")
-    return batch
 
 
 def _normalise_model_name(model, models_yaml_path):
@@ -117,6 +108,8 @@ def run_training(
     seed=88,
     # --- Verbosity ---
     debug=False,
+    # --- Batch size ---
+    batch_size=-1,
 ):
     """
     Run the OCTRON/YOLO training pipeline.
@@ -171,9 +164,13 @@ def run_training(
     seed : int
         Random seed for the split (ignored when ``skip_split=True``).
     """
-    from octron.yolo_octron.yolo_octron import YOLO_octron
+    from octron.yolo_octron.yolo_octron import YOLO_octron  # triggers heavy imports incl. ultralytics
+    from octron._logging import setup_logging
     from octron.test_gpu import auto_device
     from octron.tools.split import run_split
+    # Evict any loguru handler ultralytics installed during its import so all
+    # subsequent output flows through our single, consistently-filtered handler.
+    setup_logging(debug=debug)
 
     # Unwrap enums to plain strings
     device = device.value if hasattr(device, 'value') else str(device)
@@ -212,13 +209,13 @@ def run_training(
     last_pt = output_base / run_name / "weights" / "last.pt"
     if resume:
         if best_pt.exists():
-            print(f"Training already completed ({best_pt}). Nothing to resume. Use --overwrite to retrain from scratch.")
+            logger.info(f"Training already completed ({best_pt}). Nothing to resume. Use --overwrite to retrain from scratch.")
             return
         if not last_pt.exists():
-            print("No interrupted training found (last.pt missing). Starting fresh.")
+            logger.info("No interrupted training found (last.pt missing). Starting fresh.")
             resume = False
     elif best_pt.exists() and not overwrite:
-        print(f"Trained model already exists at {best_pt}. Use --overwrite to retrain.")
+        logger.info(f"Trained model already exists at {best_pt}. Use --overwrite to retrain.")
         return
 
     if device == "auto":
@@ -231,7 +228,7 @@ def run_training(
     # large projects.  If the yolo_config.yaml is already present the data is
     # ready to use; pass --overwrite to force regeneration.
     if not skip_split and config_path.exists() and not overwrite:
-        print(
+        logger.info(
             f"Training data already exists at {config_path.parent} — skipping data "
             "preparation. Delete the training_data folder or use --overwrite to regenerate."
         )
@@ -264,19 +261,20 @@ def run_training(
     yolo.training_path = output_base
 
     if resume:
-        print(f"Resuming from checkpoint: {last_pt}")
+        logger.info(f"Resuming from checkpoint: {last_pt}")
         yolo.load_model(last_pt, train_mode=train_mode)
     else:
         model = _normalise_model_name(model, _MODELS_YAML)
-        print(f"Loading model: {model}...")
+        logger.info(f"Loading model: {model}...")
         yolo.load_model(model, train_mode=train_mode)
 
     # --- Step 6: train ---
-    batch = _get_batch_size(yolo, imagesz)
-
-    print(f"Training for {epochs} epochs on {device}...")
-    print(f"Run name: {run_name}")
-    print(f"Output:   {output_base / run_name}")
+    # batch_size=-1 tells ultralytics to run AutoBatch internally, after the
+    # model has been placed on the target device — this gives accurate VRAM
+    # readings.  Callers can pass a positive integer to fix the batch size.
+    logger.info(f"Training for {epochs} epochs on {device}...")
+    logger.info(f"Run name: {run_name}")
+    logger.info(f"Output:   {output_base / run_name}")
     for progress in yolo.train(
         device=device,
         imagesz=imagesz,
@@ -284,7 +282,7 @@ def run_training(
         save_period=save_period,
         train_mode=train_mode,
         resume=resume,
-        batch=batch,
+        batch=batch_size,
         run_name=run_name,
         debug=debug,
     ):
@@ -293,4 +291,4 @@ def run_training(
         remaining = progress.get("remaining_time", 0)
         print(f"  Epoch {epoch}/{total_epochs} | ETA: {remaining:.0f}s", end="\r")
     print()
-    print("Training complete.")
+    logger.info("Training complete.")

--- a/octron/tools/train.py
+++ b/octron/tools/train.py
@@ -186,15 +186,15 @@ def run_training(
             train_mode = yaml_mode
         config_path = data_dir / "yolo_config.yaml"
         img_search_path = data_dir
-        output_base = Path(output_dir) if output_dir else data_dir / "model"
+        output_base = (Path(output_dir) if output_dir else data_dir / "model").resolve()
         skip_split = True  # external data is already prepared
     else:
         if project_path is None:
             raise ValueError("Either project_path or data_dir must be provided.")
-        project_path = Path(project_path)
+        project_path = Path(project_path).resolve()
         config_path = project_path / "model" / "training_data" / "yolo_config.yaml"
         img_search_path = project_path / "model" / "training_data"
-        output_base = Path(output_dir) if output_dir else project_path / "model"
+        output_base = (Path(output_dir) if output_dir else project_path / "model").resolve()
 
     # Default train_mode if still unresolved
     if train_mode is None:

--- a/octron/tools/train.py
+++ b/octron/tools/train.py
@@ -148,6 +148,8 @@ def run_training(
     train_fraction=0.7,
     val_fraction=0.15,
     seed=88,
+    # --- Verbosity ---
+    debug=False,
 ):
     """
     Run the OCTRON/YOLO training pipeline.
@@ -319,6 +321,7 @@ def run_training(
         resume=resume,
         batch=batch,
         run_name=run_name,
+        debug=debug,
     ):
         epoch = progress.get("epoch", "?")
         total_epochs = progress.get("total_epochs", "?")

--- a/octron/tools/train.py
+++ b/octron/tools/train.py
@@ -127,18 +127,23 @@ def _validate_data_dir(data_dir: Path):
 
 
 def run_training(
+    # --- Data source ---
     project_path=None,
     data_dir: Optional[Path] = None,
-    output_dir: Optional[Path] = None,
-    run_name: Optional[str] = None,
+    # --- Model ---
     model="YOLO26m",
     train_mode=None,
-    device="auto",
+    # --- Core hyperparameters ---
     epochs=250,
     imagesz=640,
+    device="auto",
     save_period=50,
+    # --- Output control ---
+    output_dir: Optional[Path] = None,
+    run_name: Optional[str] = None,
     overwrite=False,
     resume=False,
+    # --- Data split (OCTRON projects only) ---
     skip_split=False,
     train_fraction=0.7,
     val_fraction=0.15,
@@ -162,6 +167,20 @@ def run_training(
         Path to an external YOLO training data directory. When provided,
         ``skip_split`` is implied and ``train_mode`` is read from
         ``yolo_config.yaml`` if not explicitly supplied.
+    model : str or Path
+        YOLO model name (e.g. 'YOLO11m') or path to an existing model file.
+    train_mode : str or None
+        'segment' or 'detect'. When ``None`` and ``data_dir`` is provided the
+        value is read from ``yolo_config.yaml``; falls back to 'segment'.
+    epochs : int
+        Number of training epochs.
+    imagesz : int
+        Input image size for training.
+    device : str
+        Device to train on ('auto', 'cpu', 'cuda', 'mps'). 'auto' selects
+        CUDA if available, then MPS, then CPU.
+    save_period : int
+        Save a checkpoint every N epochs.
     output_dir : Path, optional
         Base directory where the training run folder will be created.
         Defaults to ``<project_path>/model/`` or ``<data_dir>/model/``.
@@ -169,20 +188,8 @@ def run_training(
         Name of the training run subdirectory. When ``None`` the GUI default
         ``'training'`` is used, preserving existing behaviour. CLI callers
         should pass an informative name such as ``'yolo26m_seg_640_20260327'``.
-    model : str or Path
-        YOLO model name (e.g. 'YOLO11m') or path to an existing model file.
-    train_mode : str or None
-        'segment' or 'detect'. When ``None`` and ``data_dir`` is provided the
-        value is read from ``yolo_config.yaml``; falls back to 'segment'.
-    device : str
-        Device to train on ('auto', 'cpu', 'cuda', 'mps'). 'auto' selects
-        CUDA if available, then MPS, then CPU.
-    epochs : int
-        Number of training epochs.
-    imagesz : int
-        Input image size for training.
-    save_period : int
-        Save a checkpoint every N epochs.
+    overwrite : bool
+        Overwrite an existing trained model. Default: skip if best.pt exists.
     resume : bool
         Resume training from an existing last.pt checkpoint.
     skip_split : bool

--- a/octron/tools/train.py
+++ b/octron/tools/train.py
@@ -10,52 +10,19 @@ External training data (not from an OCTRON project) can be used by passing
 together with the standard YOLO train/val/test split subdirectories.
 """
 
-import json
 from pathlib import Path
 from typing import Optional
 
 _MODELS_YAML = Path(__file__).parent.parent / "yolo_octron" / "yolo_models.yaml"
 
 
-def _get_batch_size(model, imgsz, device, cache_path):
-    """
-    Return the optimal batch size for training, using a cache to avoid
-    running AutoBatch on every training run.
-
-    The cache is stored at ``cache_path`` and keyed by model architecture,
-    image size, and GPU name so it stays valid across runs with the same
-    hardware and model.
-    """
-    import torch
-
-    gpu_name = (
-        torch.cuda.get_device_name(device) if torch.cuda.is_available() else "cpu"
-    )
-    cache_key = f"{model.model.model.__class__.__name__}_{imgsz}_{gpu_name}"
-
-    cache_path = Path(cache_path)
-    cache = {}
-    if cache_path.exists():
-        try:
-            with open(cache_path) as f:
-                cache = json.load(f)
-        except Exception:
-            cache = {}
-
-    if cache_key in cache:
-        batch = cache[cache_key]
-        print(f"AutoBatch: using cached batch size {batch} for {gpu_name} (imgsz={imgsz})")
-        return batch
-
-    print("AutoBatch: running batch size search (result will be cached) ...")
+def _get_batch_size(model, imgsz):
+    """Return the optimal batch size for training via ultralytics AutoBatch."""
     from ultralytics.utils.autobatch import check_train_batch_size
-    batch = check_train_batch_size(model.model.model, imgsz=imgsz, amp=True)
 
-    cache[cache_key] = batch
-    cache_path.parent.mkdir(parents=True, exist_ok=True)
-    with open(cache_path, "w") as f:
-        json.dump(cache, f)
-    print(f"AutoBatch: batch size {batch} cached to {cache_path}")
+    print("AutoBatch: searching for optimal batch size...")
+    batch = check_train_batch_size(model.model.model, imgsz=imgsz, amp=True)
+    print(f"AutoBatch: using batch size {batch}")
     return batch
 
 
@@ -223,7 +190,6 @@ def run_training(
         config_path = data_dir / "yolo_config.yaml"
         img_search_path = data_dir
         output_base = Path(output_dir) if output_dir else data_dir / "model"
-        batch_cache = output_base / "autobatch_cache.json"
         skip_split = True  # external data is already prepared
     else:
         if project_path is None:
@@ -232,7 +198,6 @@ def run_training(
         config_path = project_path / "model" / "training_data" / "yolo_config.yaml"
         img_search_path = project_path / "model" / "training_data"
         output_base = Path(output_dir) if output_dir else project_path / "model"
-        batch_cache = project_path / "model" / "autobatch_cache.json"
 
     # Default train_mode if still unresolved
     if train_mode is None:
@@ -307,7 +272,7 @@ def run_training(
         yolo.load_model(model, train_mode=train_mode)
 
     # --- Step 6: train ---
-    batch = _get_batch_size(yolo, imagesz, device, batch_cache)
+    batch = _get_batch_size(yolo, imagesz)
 
     print(f"Training for {epochs} epochs on {device}...")
     print(f"Run name: {run_name}")

--- a/octron/tools/train.py
+++ b/octron/tools/train.py
@@ -258,6 +258,18 @@ def run_training(
         device = auto_device()
 
     # --- Steps 1–4: prepare and export training data (OCTRON projects only) ---
+    # Skip the expensive JSON-loading pipeline if training data is already on
+    # disk and the caller hasn't asked to overwrite it.  Preparing labels reads
+    # every object_organizer.json in the project, which can take a long time on
+    # large projects.  If the yolo_config.yaml is already present the data is
+    # ready to use; pass --overwrite to force regeneration.
+    if not skip_split and config_path.exists() and not overwrite:
+        print(
+            f"Training data already exists at {config_path.parent} — skipping data "
+            "preparation. Delete the training_data folder or use --overwrite to regenerate."
+        )
+        skip_split = True
+
     if not skip_split:
         run_split(
             project_path=project_path,

--- a/octron/yolo_octron/helpers/yolo_checks.py
+++ b/octron/yolo_octron/helpers/yolo_checks.py
@@ -30,7 +30,7 @@ def download_yolo_model(url,
     assert output_folder.is_dir(), f"Destination folder '{output_folder}' does not exist"
 
     if fpath.exists() and not overwrite:
-        logger.info(f"File '{fpath}' exists. Skipping download.")
+        logger.debug(f"File '{fpath}' exists. Skipping download.")
         return
     else:
         logger.info(f"Downloading model from {url}")
@@ -110,7 +110,7 @@ def check_yolo_models(YOLO_BASE_URL,
             model_path = (yolo_model_path / models_dict[model][path_key])
             # Check if the model file exists. If not, download it.
             if model_path.exists() and not force_download:
-                logger.info(f"Model file {model_path} exists. Skipping download.")
+                logger.debug(f"Model file {model_path} exists. Skipping download.")
             else:
                 logger.info(f'Trying to download {path_key} for {model} (force_download={force_download})')
                 model_name = model_path.name

--- a/octron/yolo_octron/yolo_octron.py
+++ b/octron/yolo_octron/yolo_octron.py
@@ -1377,20 +1377,11 @@ class YOLO_octron:
                     # validation — resulting in mask metrics = 0 for all epochs.
                     train_kwargs['mask_ratio'] = 1
                     train_kwargs['overlap_mask'] = True
-                    # YOLO26 has a semantic-segmentation head (sem_loss) that
-                    # requires per-pixel class-label targets.  OCTRON provides
-                    # instance-level polygon labels only.  Disabling the semantic
-                    # loss prevents sem_loss from diverging to NaN when it cannot
-                    # find valid semantic targets.
-                    # Only set this for YOLO26 models (identified by the Segment26
-                    # head) — YOLO11 does not have this parameter and passing it
-                    # would cause an unrecognised-argument error.
-                    try:
-                        head_type = type(list(self.model.model.model.children())[-1]).__name__
-                    except Exception:
-                        head_type = ''
-                    if 'Segment26' in head_type:
-                        train_kwargs['semseg_loss'] = False
+                    # Note: YOLO26 was trained with semseg_loss=True in its
+                    # custom ultralytics fork, but the standard ultralytics
+                    # rejects it as an unrecognised argument. Since the standard
+                    # trainer has no semantic-loss code, sem_loss is not computed
+                    # at all — no action needed here.
 
                 self.model.train(**train_kwargs)
             except Exception as e:

--- a/octron/yolo_octron/yolo_octron.py
+++ b/octron/yolo_octron/yolo_octron.py
@@ -1284,6 +1284,12 @@ class YOLO_octron:
             # https://docs.ultralytics.com/modes/train/#resuming-interrupted-trainings
             # overlap_mask - https://github.com/ultralytics/ultralytics/issues/3213#issuecomment-2799841153
             nonlocal training_error
+            # Re-apply our logging configuration.  ultralytics installs its own
+            # loguru handler when first imported; calling setup_logging() here
+            # (after import, inside the training thread) evicts it so all output
+            # flows through our single, consistently-filtered handler.
+            from octron._logging import setup_logging as _setup_logging
+            _setup_logging(debug=debug)
             try:
                 img_height, img_width, rect = _find_train_image_size(self.data_path)
                 # Start training

--- a/octron/yolo_octron/yolo_octron.py
+++ b/octron/yolo_octron/yolo_octron.py
@@ -1120,6 +1120,7 @@ class YOLO_octron:
               train_mode='segment',
               resume=False,
               batch=-1,
+              run_name='training',
               ):
         """
         Train the YOLO model with epoch progress updates
@@ -1139,7 +1140,11 @@ class YOLO_octron:
         resume : bool
             If True, resume training from the loaded checkpoint (last.pt).
             Most training parameters are restored from the checkpoint.
-            
+        run_name : str
+            Name of the training run subdirectory inside ``training_path``.
+            Defaults to ``'training'`` (preserves GUI behaviour). CLI runs
+            pass an informative name such as ``'yolo26m_seg_640_20260327'``.
+
         Yields
         ------
         dict
@@ -1235,19 +1240,28 @@ class YOLO_octron:
             """
             data_path = Path(data_path)
             assert data_path.exists(), f"Data path {data_path} does not exist."
-            png_files = list(data_path.glob('**/*.png'))
-            if len(png_files) == 0:
-                raise FileNotFoundError(f"No .png files found in {data_path.as_posix()}")
-            logger.debug(f'Found {len(png_files)} png files')
-            samples = random.sample(png_files, min(max_samples, len(png_files)))
+            image_files = (
+                list(data_path.glob('**/*.png'))
+                + list(data_path.glob('**/*.jpg'))
+                + list(data_path.glob('**/*.jpeg'))
+            )
+            if len(image_files) == 0:
+                raise FileNotFoundError(f"No image files (.png/.jpg) found in {data_path.as_posix()}")
+            logger.debug(f'Found {len(image_files)} image files')
+            samples = random.sample(image_files, min(max_samples, len(image_files)))
 
             widths, heights = [], []
             for fpath in samples:
-                # Read width/height directly from PNG IHDR chunk (bytes 16-23)
-                # I had it on PIL.Image.open() per file first, but this is very slow ... 
-                with open(fpath, 'rb') as f:
-                    f.seek(16)
-                    w, h = struct.unpack('>II', f.read(8))
+                if fpath.suffix.lower() == '.png':
+                    # Read width/height directly from PNG IHDR chunk (bytes 16-23)
+                    # I had it on PIL.Image.open() per file first, but this is very slow ...
+                    with open(fpath, 'rb') as f:
+                        f.seek(16)
+                        w, h = struct.unpack('>II', f.read(8))
+                else:
+                    from PIL import Image
+                    with Image.open(fpath) as img:
+                        w, h = img.size
                 widths.append(w)
                 heights.append(h)
             
@@ -1298,7 +1312,7 @@ class YOLO_octron:
                 copy_paste_prob = 0.0 if rect else 0.25
                 train_kwargs = dict(
                     data=self.config_path.as_posix() if self.config_path is not None else '',
-                    name='training',
+                    name=run_name,
                     project=self.training_path.as_posix() if self.training_path is not None else '',
                     mode=train_mode,
                     device=device,

--- a/octron/yolo_octron/yolo_octron.py
+++ b/octron/yolo_octron/yolo_octron.py
@@ -1256,20 +1256,17 @@ class YOLO_octron:
             return avg_h, avg_w, rect
 
         # Remove any stale ultralytics disk-cache .npy files from the training
-        # data directory before starting.  ultralytics cache='disk' (older
-        # versions) writes <stem>.npy alongside each source image.  YOLO26's
-        # semantic-segmentation head also scans for <stem>.npy files and
-        # interprets them as per-pixel class-label maps.  Stale cache files
-        # therefore contain raw RGB frames instead of label maps, which poisons
-        # sem_loss and eventually causes a NaN crash (observed at epoch ~76 on
-        # RTX 5090 with yolo26l-seg).  Removing them forces a clean rebuild and
-        # prevents the semantic head from receiving corrupted targets.
+        # data directory before starting.  ultralytics cache='disk' writes
+        # <stem>.npy files alongside source images, and BaseDataset.load_image
+        # will silently load any matching .npy it finds — even when cache='disk'
+        # is not set — instead of reading the actual image file.  Purging them
+        # here ensures a clean cache rebuild each training run.
         if self.data_path and self.data_path.exists():
             stale_npy = list(self.data_path.glob('**/*.npy'))
             if stale_npy:
                 logger.warning(
-                    f"Found {len(stale_npy)} stale .npy file(s) in training data "
-                    "directory — removing to prevent corrupted semantic-mask targets."
+                    f"Found {len(stale_npy)} stale .npy cache file(s) in training data "
+                    "directory — removing before training starts."
                 )
                 for f in stale_npy:
                     f.unlink()
@@ -1337,7 +1334,7 @@ class YOLO_octron:
                     patience=100,
                     plots=True,
                     batch=batch,
-                    cache=False,
+                    cache='disk', # for fast access
                     save=True,
                     save_period=save_period,
                     exist_ok=True,

--- a/octron/yolo_octron/yolo_octron.py
+++ b/octron/yolo_octron/yolo_octron.py
@@ -1134,6 +1134,17 @@ class YOLO_octron:
             for callback_name in ['on_fit_epoch_end', 'on_train_start', 'on_train_end']:
                 if callback_name in self.model.callbacks:
                     self.model.callbacks.pop(callback_name, None)
+
+        # Callback to log the batch size chosen by ultralytics AutoBatch
+        def _on_train_start(trainer):
+            try:
+                chosen = getattr(trainer, 'batch_size', None)
+                if chosen is None:
+                    chosen = getattr(trainer.args, 'batch', None)
+                if chosen is not None:
+                    logger.info(f"Batch size: {chosen}")
+            except Exception:
+                pass
                     
         # Setup a queue to receive yielded values from the callback
         progress_queue = queue.Queue()
@@ -1265,6 +1276,7 @@ class YOLO_octron:
 
         self.model.add_callback("on_fit_epoch_end", _on_fit_epoch_end)
         self.model.add_callback("on_train_end", _on_train_end)
+        self.model.add_callback("on_train_start", _on_train_start)
         
         if self.config_path is None or not self.config_path.exists():
             raise FileNotFoundError(
@@ -1296,6 +1308,11 @@ class YOLO_octron:
                 logger.info(f"Starting training for {epochs} epochs...")
                 logger.info(f"Setting rect={rect} based on training image size of {img_width}x{img_height} (wxh)")
                 logger.info(f"Using device: {device}")
+                if batch == -1:
+                    logger.info(
+                        "Batch size: auto — ultralytics will probe VRAM to find the "
+                        "optimal size before the first epoch (may take a minute or two)."
+                    )
                 logger.info("################################################################")
                 # Build training kwargs — shared between segment and detect
                 # When rect=True, images in different batches have different padded heights

--- a/octron/yolo_octron/yolo_octron.py
+++ b/octron/yolo_octron/yolo_octron.py
@@ -1275,6 +1275,25 @@ class YOLO_octron:
             
             return avg_h, avg_w, rect
 
+        # Remove any stale ultralytics disk-cache .npy files from the training
+        # data directory before starting.  ultralytics cache='disk' (older
+        # versions) writes <stem>.npy alongside each source image.  YOLO26's
+        # semantic-segmentation head also scans for <stem>.npy files and
+        # interprets them as per-pixel class-label maps.  Stale cache files
+        # therefore contain raw RGB frames instead of label maps, which poisons
+        # sem_loss and eventually causes a NaN crash (observed at epoch ~76 on
+        # RTX 5090 with yolo26l-seg).  Removing them forces a clean rebuild and
+        # prevents the semantic head from receiving corrupted targets.
+        if self.data_path and self.data_path.exists():
+            stale_npy = list(self.data_path.glob('**/*.npy'))
+            if stale_npy:
+                logger.warning(
+                    f"Found {len(stale_npy)} stale .npy file(s) in training data "
+                    "directory — removing to prevent corrupted semantic-mask targets."
+                )
+                for f in stale_npy:
+                    f.unlink()
+
         self.model.add_callback("on_fit_epoch_end", _on_fit_epoch_end)
         self.model.add_callback("on_train_end", _on_train_end)
         
@@ -1326,7 +1345,7 @@ class YOLO_octron:
                     patience=100,
                     plots=True,
                     batch=batch,
-                    cache='disk', # for fast access
+                    cache=False,
                     save=True,
                     save_period=save_period,
                     exist_ok=True,
@@ -1351,8 +1370,27 @@ class YOLO_octron:
                 )
                 # Segmentation-specific parameters
                 if train_mode == 'segment':
-                    train_kwargs['mask_ratio'] = 2
+                    # mask_ratio=1 matches the YOLO26 prototype head's design
+                    # resolution. Using mask_ratio=2 causes YOLO26's mask
+                    # predictions to be at half the expected resolution, which
+                    # prevents any mask IoU threshold from being met during
+                    # validation — resulting in mask metrics = 0 for all epochs.
+                    train_kwargs['mask_ratio'] = 1
                     train_kwargs['overlap_mask'] = True
+                    # YOLO26 has a semantic-segmentation head (sem_loss) that
+                    # requires per-pixel class-label targets.  OCTRON provides
+                    # instance-level polygon labels only.  Disabling the semantic
+                    # loss prevents sem_loss from diverging to NaN when it cannot
+                    # find valid semantic targets.
+                    # Only set this for YOLO26 models (identified by the Segment26
+                    # head) — YOLO11 does not have this parameter and passing it
+                    # would cause an unrecognised-argument error.
+                    try:
+                        head_type = type(list(self.model.model.model.children())[-1]).__name__
+                    except Exception:
+                        head_type = ''
+                    if 'Segment26' in head_type:
+                        train_kwargs['semseg_loss'] = False
 
                 self.model.train(**train_kwargs)
             except Exception as e:

--- a/octron/yolo_octron/yolo_octron.py
+++ b/octron/yolo_octron/yolo_octron.py
@@ -1089,6 +1089,7 @@ class YOLO_octron:
               resume=False,
               batch=-1,
               run_name='training',
+              debug=False,
               ):
         """
         Train the YOLO model with epoch progress updates
@@ -1317,6 +1318,7 @@ class YOLO_octron:
                     save=True,
                     save_period=save_period,
                     exist_ok=True,
+                    verbose=debug,  # suppress architecture table and param dump unless --debug
                     nms=False,
                     max_det=2000, # Increasing this for dense scenes - I think it might affect val too
                     # Augmentation

--- a/octron/yolo_octron/yolo_octron.py
+++ b/octron/yolo_octron/yolo_octron.py
@@ -19,7 +19,6 @@ from datetime import datetime
 from PIL import Image
 import yaml
 import json 
-from tqdm import tqdm
 import numpy as np
 from natsort import natsorted
 import zarr 
@@ -367,12 +366,7 @@ class YOLO_octron:
                         
                 ##################################################################################
                 polys = {} # Collected polygons over frame indices
-                for f_no, f in tqdm(enumerate(frames, start=1), 
-                            desc=f'Polygons for label {label}', 
-                            total=len(frames),
-                            unit='frames',
-                            leave=True
-                            ):    
+                for f_no, f in enumerate(frames, start=1):
                     mask_polys = [] # List of polygons for the current frame
                     for mask_array in mask_arrays:
                         mask_raw = mask_array[f]
@@ -556,11 +550,7 @@ class YOLO_octron:
 
                 ##################################################################################
                 bboxes_dict = {}  # frame_id -> list of bbox tuples
-                for f_no, f in tqdm(enumerate(frames, start=1),
-                                    desc=f'Bboxes for label {label}',
-                                    total=len(frames),
-                                    unit='frames',
-                                    leave=True):
+                for f_no, f in enumerate(frames, start=1):
                     frame_bboxes = []
                     for mask_array in mask_arrays:
                         mask_raw = mask_array[f]
@@ -768,29 +758,17 @@ class YOLO_octron:
             path_prefix = Path(path).name   
             video_data = labels.pop('video')
             _ = labels.pop('video_file_path')
-            for entry in tqdm(labels,
-                            total=len(labels),
-                            position=0,
-                            unit='labels',
-                            leave=True,
-                            desc=f'Exporting {len(labels)} label(s)'
-                            ):
+            for entry in labels:
                 current_label_id = entry
-                label = labels[entry]['label']  
-                # Extract the size of the masks for normalization later on 
+                label = labels[entry]['label']
+                # Extract the size of the masks for normalization later on
                 for m in labels[entry]['masks']:
                     assert m.shape == labels[entry]['masks'][0].shape, f'All masks should have the same shape'
                 _, mask_height, mask_width = labels[entry]['masks'][0].shape
-                
+
                 for split in ['train', 'val', 'test']:
                     current_indices = labels[entry]['frames_split'][split]
-                    for frame_no, frame_id in tqdm(enumerate(current_indices),
-                                                    total=len(current_indices), 
-                                                    desc=f'Exporting {split} frames', 
-                                                    position=1,    
-                                                    unit='frames',
-                                                    leave=False,
-                                                    ):
+                    for frame_no, frame_id in enumerate(current_indices):
                         frame = video_data[frame_id]
                         image_output_path = self.data_path / split / f'{path_prefix}_{frame_id}.png'
                         if not image_output_path.exists():
@@ -908,23 +886,13 @@ class YOLO_octron:
             path_prefix = Path(path).name
             video_data = labels.pop('video')
             _ = labels.pop('video_file_path')
-            for entry in tqdm(labels,
-                              total=len(labels),
-                              position=0,
-                              unit='labels',
-                              leave=True,
-                              desc=f'Exporting {len(labels)} label(s)'):
+            for entry in labels:
                 current_label_id = entry
                 label = labels[entry]['label']
 
                 for split in ['train', 'val', 'test']:
                     current_indices = labels[entry]['frames_split'][split]
-                    for frame_no, frame_id in tqdm(enumerate(current_indices),
-                                                    total=len(current_indices),
-                                                    desc=f'Exporting {split} frames',
-                                                    position=1,
-                                                    unit='frames',
-                                                    leave=False):
+                    for frame_no, frame_id in enumerate(current_indices):
                         frame = video_data[frame_id]
                         image_output_path = self.data_path / split / f'{path_prefix}_{frame_id}.png'
                         if not image_output_path.exists():


### PR DESCRIPTION
## Summary

- Add `--data-dir` flag to `octron train` to support external YOLO training data (skips data preparation when data already exists)
- Add `--debug` flag to `octron train` for verbose output
- Implement AutoBatch with progress logging to automatically determine optimal batch size
- Route ultralytics/third-party loggers through loguru and suppress noisy output during training
- Replace tqdm bars in split pipeline with single-line ANSI progress

## Test plan

- [ ] Run `octron train` with internal data (no `--data-dir`) — verify existing behaviour unchanged
- [ ] Run `octron train --data-dir <path>` with pre-prepared YOLO data — verify training starts without re-preparing data
- [ ] Run `octron train --debug` and verify verbose ultralytics output is visible
- [ ] Verify AutoBatch selects a reasonable batch size and logs it clearly
- [ ] Verify third-party warnings appear at most once per session (not per epoch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)