### PR TITLE
feat: add export_tracking pipeline with robust centroid resolution

### DIFF
--- a/octron/cli.py
+++ b/octron/cli.py
@@ -287,8 +287,16 @@ def export(
         callback=_list_properties_callback,
         is_eager=True,
     ),
+    debug: bool = typer.Option(
+        False, "--debug",
+        help="Enable debug logging with millisecond timestamps and per-step timing.",
+    ),
 ):
     """Export tracking CSVs from an existing OCTRON predictions directory."""
+    if debug:
+        from octron._logging import setup_logging
+        setup_logging(debug=True)
+
     from octron.tools.export_tracking import export_tracking
 
     _rp = region_properties.strip().lower() if region_properties is not None else None

--- a/octron/cli.py
+++ b/octron/cli.py
@@ -266,6 +266,8 @@ def export(
             "Which regionprop columns to write. "
             "'all' or omit: keep every column in the existing CSV. "
             "'none': strip all regionprop columns. "
+            "'shape': all size-and-shape properties. "
+            "'intensity': all intensity properties. "
             "Otherwise a comma-separated list of names "
             "(e.g. 'eccentricity,solidity'). "
             "Use --list-properties to see available names."
@@ -289,10 +291,11 @@ def export(
     """Export tracking CSVs from an existing OCTRON predictions directory."""
     from octron.tools.export_tracking import export_tracking
 
-    if region_properties is None or region_properties.strip().lower() == "all":
+    _rp = region_properties.strip().lower() if region_properties is not None else None
+    if _rp is None or _rp == "all":
         parsed_props = None
-    elif region_properties.strip().lower() == "none":
-        parsed_props = "none"
+    elif _rp in ("none", "shape", "intensity"):
+        parsed_props = _rp
     else:
         parsed_props = [p.strip() for p in region_properties.split(",") if p.strip()]
 

--- a/octron/cli.py
+++ b/octron/cli.py
@@ -228,7 +228,7 @@ def predict(
     )
 
 
-class CentroidMethod(str, Enum):
+class Method(str, Enum):
     largest  = "largest"
     weighted = "weighted"
     mask_com = "mask_com"
@@ -251,20 +251,21 @@ def export(
         None, "--output-dir", "-o",
         help="Where to write the output CSV(s). Defaults to the predictions directory.",
     ),
-    centroid_method: CentroidMethod = typer.Option(
-        CentroidMethod.largest, "--centroid-method",
+    method: Method = typer.Option(
+        Method.largest, "--method",
         help=(
-            "How to compute centroid_x/centroid_y. "
-            "'largest': centroid of the single largest segment (default, fast). "
+            "How to resolve multi-segment frames. "
+            "'largest': use values from the single largest segment (default). "
             "'weighted': area-weighted mean across all segments. "
-            "'mask_com': full centre-of-mass from zarr masks (most robust, slower)."
+            "'mask_com': centre-of-mass from zarr masks for pos_x/y (most robust)."
         ),
     ),
     region_properties: Optional[str] = typer.Option(
         None, "--region-properties",
         help=(
             "Which regionprop columns to write. "
-            "'all' or omit: keep every column in the existing CSV. "
+            "Omit: keep columns already in the CSV, no zarr computation. "
+            "'all': compute every available property. "
             "'none': strip all regionprop columns. "
             "'shape': all size-and-shape properties. "
             "'intensity': all intensity properties. "
@@ -300,9 +301,9 @@ def export(
     from octron.tools.export_tracking import export_tracking
 
     _rp = region_properties.strip().lower() if region_properties is not None else None
-    if _rp is None or _rp == "all":
+    if _rp is None:
         parsed_props = None
-    elif _rp in ("none", "shape", "intensity"):
+    elif _rp in ("none", "all", "shape", "intensity"):
         parsed_props = _rp
     else:
         parsed_props = [p.strip() for p in region_properties.split(",") if p.strip()]
@@ -310,7 +311,7 @@ def export(
     export_tracking(
         predictions_path=predictions_path,
         output_dir=output_dir,
-        centroid_method=centroid_method.value,
+        method=method.value,
         region_properties=parsed_props,
         combined=combined,
         overwrite=overwrite,

--- a/octron/cli.py
+++ b/octron/cli.py
@@ -234,6 +234,11 @@ class Method(str, Enum):
     mask_com = "mask_com"
 
 
+class Format(str, Enum):
+    csv     = "csv"
+    parquet = "parquet"
+
+
 def _list_properties_callback(value: bool):
     if value:
         from octron.tools.export_tracking import list_region_properties
@@ -282,13 +287,17 @@ def export(
             "Auto-detected from the predictions directory name if not provided."
         ),
     ),
+    fmt: Format = typer.Option(
+        Format.csv, "--format",
+        help="Output format. 'csv' (default) or 'parquet' (requires pyarrow).",
+    ),
     combined: bool = typer.Option(
         False, "--combined",
-        help="Write a single all_tracks.csv instead of one file per track.",
+        help="Write a single all_tracks.<ext> instead of one file per track.",
     ),
     overwrite: bool = typer.Option(
         False, "--overwrite",
-        help="Overwrite existing output CSV files. Default: raise an error if files already exist.",
+        help="Overwrite existing output files. Default: raise an error if files already exist.",
     ),
     list_properties: bool = typer.Option(
         False, "--list-properties",
@@ -322,6 +331,7 @@ def export(
         method=method.value,
         region_properties=parsed_props,
         video_path=video_path,
+        fmt=fmt.value,
         combined=combined,
         overwrite=overwrite,
     )

--- a/octron/cli.py
+++ b/octron/cli.py
@@ -10,6 +10,7 @@ Subcommands
   split       Prepare and export train/val/test data from an OCTRON project
   train       Prepare training data and run YOLO model training
   predict     Run YOLO prediction and tracking on one or more videos
+  export      Export tracking CSVs from an existing predictions directory
   render      Render annotated video(s) from prediction output
               (use --bbox-sizes to report bbox sizes instead of rendering)
   transcode   Transcode video files to MP4 (H.264/libx264) using ffmpeg
@@ -224,6 +225,61 @@ def predict(
         region_properties=DEFAULT_REGION_PROPERTIES if detailed else None,
         output_dir=output_dir,
         local_cache_dir=local_cache_dir,
+    )
+
+
+class CentroidMethod(str, Enum):
+    largest  = "largest"
+    weighted = "weighted"
+    mask_com = "mask_com"
+
+
+@app.command()
+def export(
+    predictions_path: Path = typer.Argument(
+        ...,
+        help="Path to an octron_predictions/<video>/ output directory.",
+    ),
+    output_dir: Optional[Path] = typer.Option(
+        None, "--output-dir", "-o",
+        help="Where to write the output CSV(s). Defaults to the predictions directory.",
+    ),
+    centroid_method: CentroidMethod = typer.Option(
+        CentroidMethod.largest, "--centroid-method",
+        help=(
+            "How to compute centroid_x/centroid_y. "
+            "'largest': centroid of the single largest segment (default, fast). "
+            "'weighted': area-weighted mean across all segments. "
+            "'mask_com': full centre-of-mass from zarr masks (most robust, slower)."
+        ),
+    ),
+    region_properties: Optional[str] = typer.Option(
+        None, "--region-properties",
+        help=(
+            "Comma-separated list of regionprop column names to include "
+            "(e.g. 'area,eccentricity,solidity'). "
+            "Omit to keep every column found in the existing CSV."
+        ),
+    ),
+    combined: bool = typer.Option(
+        False, "--combined",
+        help="Write a single all_tracks.csv instead of one file per track.",
+    ),
+):
+    """Export tracking CSVs from an existing OCTRON predictions directory."""
+    from octron.tools.export_tracking import export_tracking
+
+    parsed_props = (
+        [p.strip() for p in region_properties.split(",") if p.strip()]
+        if region_properties is not None else None
+    )
+
+    export_tracking(
+        predictions_path=predictions_path,
+        output_dir=output_dir,
+        centroid_method=centroid_method.value,
+        region_properties=parsed_props,
+        combined=combined,
     )
 
 

--- a/octron/cli.py
+++ b/octron/cli.py
@@ -265,6 +265,10 @@ def export(
         False, "--combined",
         help="Write a single all_tracks.csv instead of one file per track.",
     ),
+    overwrite: bool = typer.Option(
+        False, "--overwrite",
+        help="Overwrite existing output CSV files. Default: raise an error if files already exist.",
+    ),
 ):
     """Export tracking CSVs from an existing OCTRON predictions directory."""
     from octron.tools.export_tracking import export_tracking
@@ -280,6 +284,7 @@ def export(
         centroid_method=centroid_method.value,
         region_properties=parsed_props,
         combined=combined,
+        overwrite=overwrite,
     )
 
 

--- a/octron/cli.py
+++ b/octron/cli.py
@@ -263,9 +263,12 @@ def export(
     region_properties: Optional[str] = typer.Option(
         None, "--region-properties",
         help=(
-            "Comma-separated list of regionprop column names to include "
-            "(e.g. 'area,eccentricity,solidity'). "
-            "Omit to keep every column found in the existing CSV."
+            "Which regionprop columns to write. "
+            "'all' or omit: keep every column in the existing CSV. "
+            "'none': strip all regionprop columns. "
+            "Otherwise a comma-separated list of names "
+            "(e.g. 'eccentricity,solidity'). "
+            "Use --list-properties to see available names."
         ),
     ),
     combined: bool = typer.Option(
@@ -286,10 +289,12 @@ def export(
     """Export tracking CSVs from an existing OCTRON predictions directory."""
     from octron.tools.export_tracking import export_tracking
 
-    parsed_props = (
-        [p.strip() for p in region_properties.split(",") if p.strip()]
-        if region_properties is not None else None
-    )
+    if region_properties is None or region_properties.strip().lower() == "all":
+        parsed_props = None
+    elif region_properties.strip().lower() == "none":
+        parsed_props = "none"
+    else:
+        parsed_props = [p.strip() for p in region_properties.split(",") if p.strip()]
 
     export_tracking(
         predictions_path=predictions_path,

--- a/octron/cli.py
+++ b/octron/cli.py
@@ -274,6 +274,14 @@ def export(
             "Use --list-properties to see available names."
         ),
     ),
+    video_path: Optional[Path] = typer.Option(
+        None, "--video",
+        help=(
+            "Path to the original video file. Required for intensity properties "
+            "(intensity_mean, intensity_max, intensity_min, intensity_std). "
+            "Auto-detected from the predictions directory name if not provided."
+        ),
+    ),
     combined: bool = typer.Option(
         False, "--combined",
         help="Write a single all_tracks.csv instead of one file per track.",
@@ -313,6 +321,7 @@ def export(
         output_dir=output_dir,
         method=method.value,
         region_properties=parsed_props,
+        video_path=video_path,
         combined=combined,
         overwrite=overwrite,
     )

--- a/octron/cli.py
+++ b/octron/cli.py
@@ -234,6 +234,13 @@ class CentroidMethod(str, Enum):
     mask_com = "mask_com"
 
 
+def _list_properties_callback(value: bool):
+    if value:
+        from octron.tools.export_tracking import list_region_properties
+        list_region_properties()
+        raise typer.Exit()
+
+
 @app.command()
 def export(
     predictions_path: Path = typer.Argument(
@@ -268,6 +275,12 @@ def export(
     overwrite: bool = typer.Option(
         False, "--overwrite",
         help="Overwrite existing output CSV files. Default: raise an error if files already exist.",
+    ),
+    list_properties: bool = typer.Option(
+        False, "--list-properties",
+        help="Print all available regionprop names and exit.",
+        callback=_list_properties_callback,
+        is_eager=True,
     ),
 ):
     """Export tracking CSVs from an existing OCTRON predictions directory."""

--- a/octron/cli.py
+++ b/octron/cli.py
@@ -73,7 +73,7 @@ def default(ctx: typer.Context):
     # ctx.resilient_parsing is True during shell-completion parsing.
     # ctx.args contains args that will be forwarded to the subcommand (e.g. ['--help']).
     # Using ctx.args works with both real sys.argv and typer.testing.CliRunner.
-    _remaining = list(ctx.protected_args or []) + list(ctx.args or [])
+    _remaining = list(ctx.args or [])
     if not ctx.resilient_parsing and "--help" not in _remaining and "-h" not in _remaining:
         from octron._logging import setup_logging, print_welcome
         setup_logging()

--- a/octron/cli.py
+++ b/octron/cli.py
@@ -229,6 +229,7 @@ def predict(
 
 
 class Method(str, Enum):
+    raw      = "raw"
     largest  = "largest"
     weighted = "weighted"
     mask_com = "mask_com"
@@ -257,10 +258,12 @@ def export(
         help="Where to write the output CSV(s). Defaults to the predictions directory.",
     ),
     method: Method = typer.Option(
-        Method.largest, "--method",
+        Method.raw, "--method",
         help=(
-            "How to resolve multi-segment frames. "
-            "'largest': use values from the single largest segment (default). "
+            "How to handle multi-segment frames. "
+            "'raw': keep tuple-strings unchanged (default; matches the original "
+            "predict output, no info loss). "
+            "'largest': use values from the single largest segment. "
             "'weighted': area-weighted mean across all segments. "
             "'mask_com': centre-of-mass from zarr masks for pos_x/y (most robust)."
         ),

--- a/octron/cli.py
+++ b/octron/cli.py
@@ -232,7 +232,6 @@ class Method(str, Enum):
     raw      = "raw"
     largest  = "largest"
     weighted = "weighted"
-    mask_com = "mask_com"
 
 
 class Format(str, Enum):
@@ -264,8 +263,7 @@ def export(
             "'raw': keep tuple-strings unchanged (default; matches the original "
             "predict output, no info loss). "
             "'largest': use values from the single largest segment. "
-            "'weighted': area-weighted mean across all segments. "
-            "'mask_com': centre-of-mass from zarr masks for pos_x/y (most robust)."
+            "'weighted': area-weighted mean across all segments."
         ),
     ),
     region_properties: Optional[str] = typer.Option(
@@ -377,10 +375,6 @@ def render(
     # --- Tracklet options ---
     tracklets: bool = typer.Option(False, "--tracklets", help="Generate one crop video per tracked animal."),
     tracklet_size: Optional[str] = typer.Option("auto", "--tracklet-size", help="Side length in pixels of each tracklet crop, or 'auto' to use the largest bounding box + 20px padding."),
-    tracklet_mask_centroids: bool = typer.Option(
-        False, "--tracklet-mask-centroids",
-        help="Use mask centre-of-mass instead of bbox centre for tracklet positioning.",
-    ),
     tracklet_smooth_cutoff_hz: float = typer.Option(
         2.0, "--tracklet-smooth-cutoff", help="Butterworth low-pass cutoff (Hz) for centroid smoothing. 0=off.",
     ),
@@ -461,7 +455,6 @@ def render(
         tracklets=tracklets,
         also_overlay=resolved_masks or resolved_boxes,
         tracklet_size=parsed_tracklet_size,
-        tracklet_mask_centroids=tracklet_mask_centroids,
         tracklet_smooth_cutoff_hz=tracklet_smooth_cutoff_hz,
         tracklet_smooth_order=tracklet_smooth_order,
         tracklet_interpolate_max_gap=tracklet_interpolate,

--- a/octron/tools/export_tracking.py
+++ b/octron/tools/export_tracking.py
@@ -203,26 +203,28 @@ def _zarr_batch_worker(args):
         raw = raw_batch[fi - fi_lo]
 
         ta = _pc()
-        binary = (raw == 1).astype(_np.uint8)
+        binary = raw == 1  # bool view, no copy
         tb = _pc()
-        rows_nz, cols_nz = _np.where(binary)
-        tc = _pc()
-        if not len(rows_nz):
+        rows_any = binary.any(axis=1)
+        if not rows_any.any():
             t_binary += tb - ta
-            t_bbox += tc - tb
+            t_bbox += _pc() - tb
             continue
-        r0, r1 = int(rows_nz.min()), int(rows_nz.max()) + 1
-        c0, c1 = int(cols_nz.min()), int(cols_nz.max()) + 1
-        td = _pc()
+        cols_any = binary.any(axis=0)
+        r0 = int(rows_any.argmax())
+        r1 = int(len(rows_any) - rows_any[::-1].argmax())
+        c0 = int(cols_any.argmax())
+        c1 = int(len(cols_any) - cols_any[::-1].argmax())
+        tc = _pc()
         labeled = _measure.label(binary[r0:r1, c0:c1], background=0, connectivity=2)
-        te = _pc()
+        td = _pc()
         props = _measure.regionprops_table(labeled, properties=computable)
-        tf = _pc()
+        te = _pc()
 
         t_binary += tb - ta
-        t_bbox += td - tb
-        t_label += te - td
-        t_props += tf - te
+        t_bbox += tc - tb
+        t_label += td - tc
+        t_props += te - td
 
         frame_result = {}
         for col_key, vals in props.items():

--- a/octron/tools/export_tracking.py
+++ b/octron/tools/export_tracking.py
@@ -596,14 +596,43 @@ def _export_tracking_from_data(
             tmp.unlink(missing_ok=True)
             raise
 
-    desc = "Writing files" if fmt == "parquet" else "Writing CSVs"
     if combined:
-        all_df = pd.concat([df for _, df in dfs.values()]).sort_index()
         out_path = output_dir / f"all_tracks{ext}"
-        tqdm.write(f"Writing combined {fmt} → {out_path.name}")
-        _write(out_path, all_df)
+        tmp = out_path.with_suffix(".tmp")
+        if fmt == "parquet":
+            # Write each track as its own row group — keeps track data contiguous
+            # for better compression and selective reads without full-file scans.
+            import json
+            import pyarrow as _pa
+            import pyarrow.parquet as _pq
+            writer = None
+            try:
+                for tid, (label, df) in tqdm(
+                    dfs.items(), desc="Writing parquet", unit="track", total=len(dfs)
+                ):
+                    table = _pa.Table.from_pandas(df)
+                    if writer is None:
+                        octron_meta = {
+                            **table.schema.metadata,
+                            b"octron_metadata": json.dumps(video_metadata).encode(),
+                        }
+                        writer = _pq.ParquetWriter(tmp, table.schema.with_metadata(octron_meta))
+                    writer.write_table(table)
+                if writer:
+                    writer.close()
+                os.replace(tmp, out_path)
+            except BaseException:
+                if writer:
+                    writer.close()
+                tmp.unlink(missing_ok=True)
+                raise
+        else:
+            all_df = pd.concat([df for _, df in dfs.values()]).sort_index()
+            tqdm.write(f"Writing combined CSV → {out_path.name}")
+            _write(out_path, all_df)
         logger.debug(f"Saved combined tracking data ({len(dfs)} tracks) to {out_path.name}")
     else:
+        desc = "Writing parquet" if fmt == "parquet" else "Writing CSVs"
         for tid, (label, df) in tqdm(dfs.items(), desc=desc, unit="track", total=len(dfs)):
             out_path = output_dir / f"{label}_track_{tid}{ext}"
             _write(out_path, df)

--- a/octron/tools/export_tracking.py
+++ b/octron/tools/export_tracking.py
@@ -171,7 +171,7 @@ _INTENSITY_PROPS = frozenset({
     "intensity_max", "intensity_mean", "intensity_min", "intensity_std",
 })
 
-_PROPS_BATCH = 100  # zarr frames per contiguous read when computing props
+_PROPS_BATCH = 500  # zarr frames per contiguous read when computing props
 
 
 # ---------------------------------------------------------------------------
@@ -534,6 +534,10 @@ def compute_region_props_from_zarr(zarr_root, track_ids, frame_indices_dict, pro
     if not computable:
         return {}
 
+    import os
+    from concurrent.futures import ThreadPoolExecutor
+
+    n_workers = min(8, os.cpu_count() or 4)
     result = {}
 
     for tid in tqdm(track_ids, desc="Computing region props from masks", unit="track"):
@@ -549,36 +553,52 @@ def compute_region_props_from_zarr(zarr_root, track_ids, frame_indices_dict, pro
 
         fi_to_pos = {int(fi): i for i, fi in enumerate(frame_idxs)}
         valid_fi = sorted(fi for fi in fi_to_pos if fi < n_zarr_frames)
+        batches = [valid_fi[s : s + _PROPS_BATCH] for s in range(0, len(valid_fi), _PROPS_BATCH)]
 
         # per-frame result as list-of-dicts — handles dynamically-expanded
         # column names (e.g. moments_hu → moments_hu-0 … moments_hu-6)
         rows = [{} for _ in range(n)]
 
-        for b_start in tqdm(range(0, len(valid_fi), _PROPS_BATCH),
-                            desc=f"  track {tid}", unit="batch", leave=False):
-            batch = valid_fi[b_start : b_start + _PROPS_BATCH]
+        def _process_batch(batch):
             fi_lo, fi_hi = batch[0], batch[-1]
-            # One contiguous zarr read per batch — minimises network round-trips
-            raw_batch = np.asarray(zarr_arr[fi_lo : fi_hi + 1])  # (span, H, W)
-
+            t_io = perf_counter()
+            raw_batch = np.asarray(zarr_arr[fi_lo : fi_hi + 1])
+            t_io_done = perf_counter()
+            batch_results = {}
             for fi in batch:
                 raw = raw_batch[fi - fi_lo]
                 binary = (raw == 1).astype(np.uint8)
                 if binary.sum() == 0:
                     continue
-
                 labeled = measure.label(binary, background=0, connectivity=2)
                 props = measure.regionprops_table(labeled, properties=computable)
-
-                pos = fi_to_pos[fi]
+                frame_result = {}
                 for col_key, vals in props.items():
                     base = col_key.split("-")[0]
                     if base not in computable and col_key not in computable:
                         continue
-                    if len(vals) == 1:
-                        rows[pos][col_key] = float(vals[0])
-                    else:
-                        rows[pos][col_key] = str(tuple(float(v) for v in vals))
+                    frame_result[col_key] = (
+                        float(vals[0]) if len(vals) == 1
+                        else str(tuple(float(v) for v in vals))
+                    )
+                if frame_result:
+                    batch_results[fi_to_pos[fi]] = frame_result
+            t_cpu_done = perf_counter()
+            _log.debug(
+                f"batch {fi_lo}-{fi_hi}: "
+                f"zarr_read={t_io_done - t_io:.3f}s  "
+                f"regionprops={t_cpu_done - t_io_done:.3f}s"
+            )
+            return batch_results
+
+        with ThreadPoolExecutor(max_workers=n_workers) as executor:
+            for batch_results in tqdm(
+                executor.map(_process_batch, batches),
+                total=len(batches),
+                desc=f"  track {tid}", unit="batch", leave=False,
+            ):
+                for pos, frame_result in batch_results.items():
+                    rows[pos].update(frame_result)
 
         # Collect all column names that actually appeared (handles expansion)
         all_keys = set()

--- a/octron/tools/export_tracking.py
+++ b/octron/tools/export_tracking.py
@@ -367,10 +367,12 @@ def _export_tracking_from_data(
     # mask_com falls back to weighted for all non-centroid metrics.
     _use_weighted = centroid_method in ("weighted", "mask_com")
 
+    from tqdm import tqdm
+
     header = _build_header(video_metadata)
     dfs = {}
 
-    for tid in track_ids:
+    for tid in tqdm(track_ids, desc="Processing tracks", unit="track", total=len(track_ids)):
         if tid not in frame_indices or len(frame_indices[tid]) == 0:
             continue
 
@@ -447,7 +449,7 @@ def _export_tracking_from_data(
             all_df.to_csv(f, na_rep="NaN", lineterminator="\n")
         logger.debug(f"Saved combined tracking data ({len(dfs)} tracks) to all_tracks.csv")
     else:
-        for tid, (label, df) in dfs.items():
+        for tid, (label, df) in tqdm(dfs.items(), desc="Writing CSVs", unit="track", total=len(dfs)):
             csv_path = output_dir / f"{label}_track_{tid}.csv"
             with open(csv_path, "w") as f:
                 f.write(header)

--- a/octron/tools/export_tracking.py
+++ b/octron/tools/export_tracking.py
@@ -1,0 +1,590 @@
+"""
+OCTRON tracking export pipeline.
+
+Converts zarr mask archives and per-track CSVs produced by ``octron predict``
+into clean, analysis-ready CSV files with resolved scalar columns.
+
+All columns that contain tuple-strings (produced when multiple disconnected
+segments are detected in a single frame) are resolved to scalars using the
+chosen ``centroid_method``.  The same strategy applies to every column —
+positions, areas, shape descriptors, and intensity properties — so the output
+is always fully numeric.
+
+Centroid / resolution methods
+------------------------------
+largest   : use the value from the single largest segment per frame (default).
+            Fast, CSV-only, no zarr required.
+weighted  : area-weighted mean across all segments per frame.
+            CSV-only.  ``area`` becomes the *sum* of segment areas.
+mask_com  : ``pos_x``/``pos_y`` replaced by full centre-of-mass from zarr masks
+            (most robust against flickering outlier segments).  All other
+            columns resolved via weighted.  ``area`` is the sum of segment areas.
+            Requires the zarr archive.
+
+Special cases
+-------------
+area      : ``largest`` → area of the largest segment.
+            ``weighted`` / ``mask_com`` → sum of all segment areas.
+orientation : always resolved via ``largest`` (circular quantity; weighted mean
+              is undefined for angles).
+
+Public functions
+----------------
+export_tracking        : Export CSVs from an existing predictions directory.
+compute_mask_centroids : Compute per-frame centre-of-mass from zarr masks.
+"""
+
+import ast
+from datetime import datetime
+from pathlib import Path
+from typing import Literal
+
+import numpy as np
+
+
+# ---------------------------------------------------------------------------
+# Letterbox helper (shared with render.py)
+# ---------------------------------------------------------------------------
+
+def _letterbox_bounds(mask_h, mask_w, vid_h, vid_w):
+    """
+    Compute the video-content region within a mask stored at inference resolution.
+
+    YOLO (retina_masks=False) letterboxes frames to fit within imgsz and then
+    pads to the nearest multiple of stride (32).  The padding is centred, so the
+    actual video content starts at (pad_y, pad_x) within the stored mask.
+
+    Returns
+    -------
+    content_h, content_w : int
+    pad_y, pad_x : int
+    """
+    content_h = round(vid_h * mask_w / vid_w)
+    if content_h <= mask_h:
+        content_w = mask_w
+        pad_y = (mask_h - content_h) // 2
+        pad_x = 0
+    else:
+        content_h = mask_h
+        content_w = round(vid_w * mask_h / vid_h)
+        pad_y = 0
+        pad_x = (mask_w - content_w) // 2
+    return content_h, content_w, pad_y, pad_x
+
+
+# ---------------------------------------------------------------------------
+# compute_mask_centroids (moved from render.py)
+# ---------------------------------------------------------------------------
+
+def compute_mask_centroids(zarr_root, track_ids, frame_start, frame_end, downsample=4):
+    """
+    Compute per-frame centre-of-mass centroids directly from zarr segmentation
+    masks, as a more stable alternative to the bounding-box-derived positions
+    stored in the tracking CSVs.
+
+    Masks are downsampled before computing CoM for speed, then coordinates are
+    scaled back to full resolution.  Processing is vectorised over the batch
+    dimension — no Python loop over frames.
+
+    Parameters
+    ----------
+    zarr_root : zarr.Group
+        Root zarr group from a predictions.zarr archive.
+    track_ids : iterable
+        Track IDs to process (must match the ``{tid}_masks`` array naming).
+    frame_start : int
+        First frame index to process (inclusive).
+    frame_end : int
+        Last frame index to process (exclusive).
+    downsample : int
+        Spatial downscale factor applied before computing CoM.  ``4`` (default)
+        gives 16× fewer pixels with negligible centroid error at full resolution.
+
+    Returns
+    -------
+    centroids : dict
+        ``{track_id: {frame_idx: (cx, cy)}}`` — float pixel coordinates in the
+        original full-resolution frame.  Only frames with at least one mask
+        pixel are included.
+    """
+    _BATCH = 500
+    track_ids = list(track_ids)
+    centroids = {tid: {} for tid in track_ids}
+    n_frames = frame_end - frame_start
+    n_batches_per_track = max(1, (n_frames + _BATCH - 1) // _BATCH)
+    total_batches = len(track_ids) * n_batches_per_track
+    _bar_width = 30
+    batch_idx = 0
+
+    for tid in track_ids:
+        arr_key = f"{tid}_masks"
+        if arr_key not in zarr_root:
+            batch_idx += n_batches_per_track
+            continue
+        zarr_arr = zarr_root[arr_key]
+        n_mask_frames = zarr_arr.shape[0]
+        _mask_h, _mask_w = zarr_arr.shape[1], zarr_arr.shape[2]
+        _vid_h = zarr_arr.attrs.get('video_height', _mask_h) or _mask_h
+        _vid_w = zarr_arr.attrs.get('video_width',  _mask_w) or _mask_w
+        _c_h, _c_w, _p_y, _p_x = _letterbox_bounds(_mask_h, _mask_w, _vid_h, _vid_w)
+
+        for batch_start in range(frame_start, min(frame_end, n_mask_frames), _BATCH):
+            batch_end = min(batch_start + _BATCH, frame_end, n_mask_frames)
+            raw = np.asarray(zarr_arr[batch_start:batch_end])  # (n, H, W)
+
+            mask = (raw[:, ::downsample, ::downsample] == 1)  # (n, dH, dW) bool
+            dH, dW = mask.shape[1], mask.shape[2]
+
+            count = mask.sum(axis=(1, 2))
+            ys = np.arange(dH, dtype=np.float32)[None, :, None]
+            xs = np.arange(dW, dtype=np.float32)[None, None, :]
+            cy_ds = (mask * ys).sum(axis=(1, 2)) / np.maximum(count, 1)
+            cx_ds = (mask * xs).sum(axis=(1, 2)) / np.maximum(count, 1)
+
+            cx_full = (cx_ds * downsample - _p_x) * _vid_w / _c_w
+            cy_full = (cy_ds * downsample - _p_y) * _vid_h / _c_h
+
+            for i, frame_idx in enumerate(range(batch_start, batch_end)):
+                if count[i] > 0:
+                    centroids[tid][frame_idx] = (float(cx_full[i]), float(cy_full[i]))
+
+            batch_idx += 1
+            pct = batch_idx / total_batches
+            filled = int(_bar_width * pct)
+            bar = "█" * filled + "░" * (_bar_width - filled)
+            print(f"  [{bar}] track {tid} | {batch_start}-{batch_end} | {pct:.0%}",
+                  end="\r")
+
+    print()
+    return centroids
+
+
+# ---------------------------------------------------------------------------
+# Tuple-resolution helpers
+# ---------------------------------------------------------------------------
+
+def _parse_tuple_or_scalar(val):
+    """Return a tuple of floats from a scalar value or a tuple-string '(1.0, 2.0)'."""
+    if isinstance(val, (int, float, np.integer, np.floating)):
+        return (float(val),)
+    if isinstance(val, str) and val.startswith('('):
+        try:
+            parsed = ast.literal_eval(val)
+            if isinstance(parsed, tuple):
+                return tuple(float(v) for v in parsed)
+        except (ValueError, SyntaxError):
+            pass
+    try:
+        return (float(val),)
+    except (TypeError, ValueError):
+        return (float('nan'),)
+
+
+def _largest_idx(area_vals):
+    """Return the index of the largest segment given a tuple of area values."""
+    if len(area_vals) == 1:
+        return 0
+    return int(np.argmax(area_vals))
+
+
+def _resolve_xy_largest(xs, ys, areas):
+    """Pick the position of the largest segment for each row."""
+    cx = np.empty(len(xs), dtype=float)
+    cy = np.empty(len(ys), dtype=float)
+    for i, (x, y, a) in enumerate(zip(xs, ys, areas)):
+        xv = _parse_tuple_or_scalar(x)
+        yv = _parse_tuple_or_scalar(y)
+        av = _parse_tuple_or_scalar(a)
+        idx = _largest_idx(av)
+        cx[i] = xv[idx] if idx < len(xv) else xv[0]
+        cy[i] = yv[idx] if idx < len(yv) else yv[0]
+    return cx, cy
+
+
+def _resolve_xy_weighted(xs, ys, areas):
+    """Compute the area-weighted mean position across all segments per row."""
+    cx = np.empty(len(xs), dtype=float)
+    cy = np.empty(len(ys), dtype=float)
+    for i, (x, y, a) in enumerate(zip(xs, ys, areas)):
+        xv = np.array(_parse_tuple_or_scalar(x))
+        yv = np.array(_parse_tuple_or_scalar(y))
+        av = np.array(_parse_tuple_or_scalar(a))
+        total = av.sum()
+        if total > 0:
+            cx[i] = float((xv * av).sum() / total)
+            cy[i] = float((yv * av).sum() / total)
+        else:
+            cx[i] = float(xv.mean())
+            cy[i] = float(yv.mean())
+    return cx, cy
+
+
+def _resolve_prop_largest(values, areas):
+    """Pick the regionprop value for the largest segment per row."""
+    out = np.empty(len(values), dtype=float)
+    for i, (v, a) in enumerate(zip(values, areas)):
+        vv = _parse_tuple_or_scalar(v)
+        av = _parse_tuple_or_scalar(a)
+        idx = _largest_idx(av)
+        out[i] = vv[idx] if idx < len(vv) else vv[0]
+    return out
+
+
+def _resolve_prop_weighted(values, areas):
+    """Compute the area-weighted mean of a regionprop across all segments per row."""
+    out = np.empty(len(values), dtype=float)
+    for i, (v, a) in enumerate(zip(values, areas)):
+        vv = np.array(_parse_tuple_or_scalar(v))
+        av = np.array(_parse_tuple_or_scalar(a))
+        total = av.sum()
+        out[i] = float((vv * av).sum() / total) if total > 0 else float(vv.mean())
+    return out
+
+
+def _sum_segments_area(areas):
+    """Sum all segment areas per row to give total mask area."""
+    out = np.empty(len(areas), dtype=float)
+    for i, a in enumerate(areas):
+        out[i] = float(sum(_parse_tuple_or_scalar(a)))
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Header helpers
+# ---------------------------------------------------------------------------
+
+def _build_header(video_metadata):
+    lines = [
+        f"video_name: {video_metadata.get('video_name', 'unknown')}",
+        f"frame_count: {video_metadata.get('frame_count', '')}",
+        f"frame_count_analyzed: {video_metadata.get('frame_count_analyzed', '')}",
+        f"video_height: {video_metadata.get('video_height', '')}",
+        f"video_width: {video_metadata.get('video_width', '')}",
+        f"created_at: {video_metadata.get('created_at', str(datetime.now()))}",
+        "",  # empty separator line
+    ]
+    return '\n'.join(lines) + '\n'
+
+
+def _read_csv_metadata(csv_path, n_header_lines=7):
+    """Parse the key: value metadata from the top of a prediction CSV."""
+    meta = {}
+    with open(csv_path) as f:
+        for i, line in enumerate(f):
+            if i >= n_header_lines - 1:
+                break
+            line = line.strip()
+            if ':' in line:
+                key, _, val = line.partition(':')
+                meta[key.strip()] = val.strip()
+    return meta
+
+
+# ---------------------------------------------------------------------------
+# Private core function
+# ---------------------------------------------------------------------------
+
+def _export_tracking_from_data(
+    output_dir,
+    track_ids,
+    labels,
+    frame_counters,
+    frame_indices,
+    confidence,
+    segments_x,
+    segments_y,
+    segments_area,
+    bbox,
+    region_props,
+    video_metadata,
+    centroid_method="largest",
+    zarr_root=None,
+    combined=False,
+):
+    """
+    Build and write tracking CSVs from raw per-track arrays.
+
+    This is the single place where prediction CSVs are written — called by
+    both ``predict_batch`` (in-memory path) and ``export_tracking`` (disk path).
+
+    All tuple-valued columns (produced when multiple disconnected segments are
+    detected in a frame) are resolved to scalars using ``centroid_method``.
+    The same strategy applies to positions, areas, and all regionprops columns,
+    with two exceptions:
+
+    - ``area`` uses the *largest segment's area* for ``"largest"``, and the
+      *sum of all segment areas* for ``"weighted"`` and ``"mask_com"``.
+    - ``orientation`` always uses the largest segment (circular quantity).
+
+    Parameters
+    ----------
+    output_dir : Path or str
+    track_ids : list[int]
+    labels : dict[int, str]
+    frame_counters : dict[int, array-like]
+        Sequential counter within the analyzed frames (frame_no level).
+    frame_indices : dict[int, array-like]
+        Actual video frame indices (frame_idx level).
+    confidence : dict[int, array-like]
+    segments_x : dict[int, array-like]
+        Raw pos_x values — scalars or tuple-strings when multi-segment.
+    segments_y : dict[int, array-like]
+    segments_area : dict[int, array-like]
+        Raw area values — scalars or tuple-strings when multi-segment.
+    bbox : dict[int, dict[str, array-like]]
+        Bounding-box columns keyed by column name.
+    region_props : dict[int, dict[str, array-like]]
+        Extra regionprop columns (all columns except the above).
+    video_metadata : dict
+        Keys: video_name, frame_count, frame_count_analyzed,
+              video_height, video_width, created_at.
+    centroid_method : {"largest", "weighted", "mask_com"}
+    zarr_root : zarr.Group or None
+        Required only when centroid_method == "mask_com".
+    combined : bool
+        True → single all_tracks.csv; False → one file per track.
+    """
+    import pandas as pd
+    from loguru import logger
+
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    # Pre-compute mask centroids once across all tracks when needed
+    mask_centroids_lookup = {}
+    if centroid_method == "mask_com" and zarr_root is not None:
+        all_frames = [int(f) for tid in track_ids for f in frame_indices.get(tid, [])]
+        if all_frames:
+            print("Computing mask centroids from zarr...")
+            mask_centroids_lookup = compute_mask_centroids(
+                zarr_root, track_ids,
+                frame_start=min(all_frames),
+                frame_end=max(all_frames) + 1,
+            )
+
+    # Determine per-prop resolver based on centroid_method.
+    # mask_com falls back to weighted for all non-centroid metrics.
+    _use_weighted = centroid_method in ("weighted", "mask_com")
+
+    header = _build_header(video_metadata)
+    dfs = {}
+
+    for tid in track_ids:
+        if tid not in frame_indices or len(frame_indices[tid]) == 0:
+            continue
+
+        label = labels.get(tid, "unknown")
+        n = len(frame_indices[tid])
+
+        sx = np.asarray(segments_x.get(tid, np.full(n, np.nan)), dtype=object)
+        sy = np.asarray(segments_y.get(tid, np.full(n, np.nan)), dtype=object)
+        sa = np.asarray(segments_area.get(tid, np.ones(n)), dtype=object)
+
+        # --- pos_x / pos_y ---
+        if centroid_method == "weighted":
+            px, py = _resolve_xy_weighted(sx, sy, sa)
+        elif centroid_method == "mask_com" and mask_centroids_lookup.get(tid):
+            fi_arr = np.asarray(frame_indices[tid])
+            lookup = mask_centroids_lookup[tid]
+            px = np.array([lookup.get(int(f), (np.nan, np.nan))[0] for f in fi_arr])
+            py = np.array([lookup.get(int(f), (np.nan, np.nan))[1] for f in fi_arr])
+        else:
+            # "largest" or mask_com fallback when zarr unavailable
+            px, py = _resolve_xy_largest(sx, sy, sa)
+
+        # --- area ---
+        # "largest" → area of the largest segment.
+        # "weighted" / "mask_com" → sum of all segment areas (total mask coverage).
+        if _use_weighted:
+            area = _sum_segments_area(sa)
+        else:
+            area = _resolve_prop_largest(sa, sa)
+
+        # --- all other regionprops ---
+        resolved_props = {}
+        for prop_name, prop_values in (region_props.get(tid) or {}).items():
+            pv = np.asarray(prop_values, dtype=object)
+            # orientation is a circular quantity — always use largest segment.
+            if prop_name == "orientation" or not _use_weighted:
+                resolved_props[prop_name] = _resolve_prop_largest(pv, sa)
+            else:
+                resolved_props[prop_name] = _resolve_prop_weighted(pv, sa)
+
+        # --- Build DataFrame ---
+        data = {
+            "label":      np.full(n, label),
+            "confidence": np.asarray(confidence.get(tid, np.full(n, np.nan)), dtype=float),
+            "pos_x":      px,
+            "pos_y":      py,
+        }
+
+        for col, arr in (bbox.get(tid) or {}).items():
+            data[col] = np.asarray(arr)
+
+        data["area"] = area
+        data.update(resolved_props)
+
+        idx = pd.MultiIndex.from_arrays(
+            [
+                np.asarray(frame_counters[tid]),
+                np.asarray(frame_indices[tid]),
+                np.full(n, tid, dtype=int),
+            ],
+            names=["frame_counter", "frame_idx", "track_id"],
+        )
+        dfs[tid] = (label, pd.DataFrame(data, index=idx))
+
+    if not dfs:
+        logger.warning("No tracking data to export.")
+        return
+
+    if combined:
+        all_df = pd.concat([df for _, df in dfs.values()]).sort_index()
+        csv_path = output_dir / "all_tracks.csv"
+        with open(csv_path, "w") as f:
+            f.write(header)
+            all_df.to_csv(f, na_rep="NaN", lineterminator="\n")
+        logger.debug(f"Saved combined tracking data ({len(dfs)} tracks) to all_tracks.csv")
+    else:
+        for tid, (label, df) in dfs.items():
+            csv_path = output_dir / f"{label}_track_{tid}.csv"
+            with open(csv_path, "w") as f:
+                f.write(header)
+                df.to_csv(f, na_rep="NaN", lineterminator="\n")
+            logger.debug(f"Saved tracking data for '{label}' (track ID: {tid}) to {csv_path.name}")
+
+
+# ---------------------------------------------------------------------------
+# Public function
+# ---------------------------------------------------------------------------
+
+_CSV_HEADER_LINES = 7
+_BBOX_COLS = frozenset({"bbox_x_min", "bbox_x_max", "bbox_y_min", "bbox_y_max",
+                        "bbox_area", "bbox_aspect_ratio"})
+_BASE_COLS = frozenset({"frame_counter", "frame_idx", "track_id", "label",
+                        "confidence", "pos_x", "pos_y", "area"}) | _BBOX_COLS
+
+
+def export_tracking(
+    predictions_path,
+    output_dir=None,
+    centroid_method: Literal["largest", "weighted", "mask_com"] = "largest",
+    region_properties=None,
+    combined=False,
+):
+    """
+    Export tracking CSVs from an existing OCTRON predictions directory.
+
+    Reads the per-track CSVs and (optionally) zarr masks produced by
+    ``octron predict``, resolves all tuple-valued columns to scalars using
+    the chosen strategy, and writes new CSVs.
+
+    Parameters
+    ----------
+    predictions_path : str or Path
+        Path to an ``octron_predictions/<video>/`` output directory.
+    output_dir : str or Path or None
+        Where to write the output CSVs.  Defaults to *predictions_path*.
+    centroid_method : {"largest", "weighted", "mask_com"}
+        How to resolve multi-segment rows.  Applied consistently to all
+        columns (positions, areas, regionprops).  See module docstring.
+    region_properties : None, "all", or list[str]
+        Which regionprop columns to include in the output.
+        ``None`` / ``"all"`` → keep every column found in the existing CSV.
+        A list of names → include only those columns (if present in the CSV).
+    combined : bool
+        If True write a single ``all_tracks.csv``; otherwise one file per track.
+    """
+    import zarr
+    from natsort import natsorted
+    import pandas as pd
+    from loguru import logger
+
+    predictions_path = Path(predictions_path)
+
+    # --- Discover CSV files ---
+    csvs = natsorted(predictions_path.rglob("*track_*.csv"))
+    if not csvs:
+        raise FileNotFoundError(f"No tracking CSV files found in {predictions_path}")
+    logger.info(f"Found {len(csvs)} tracking CSV(s) in {predictions_path.name}")
+
+    # --- Discover zarr (optional; required only for mask_com) ---
+    zarr_root = None
+    zarr_paths = list(predictions_path.rglob("predictions.zarr"))
+    if zarr_paths:
+        store = zarr.storage.LocalStore(zarr_paths[0], read_only=True)
+        zarr_root = zarr.open_group(store=store, mode="r")
+        logger.info("Found zarr archive")
+    elif centroid_method == "mask_com":
+        logger.warning(
+            "centroid_method='mask_com' requested but no zarr archive found — "
+            "falling back to 'largest'."
+        )
+        centroid_method = "largest"
+
+    # --- Read each CSV ---
+    track_ids      = []
+    labels         = {}
+    frame_counters = {}
+    frame_indices  = {}
+    confidence_d   = {}
+    segments_x_d   = {}
+    segments_y_d   = {}
+    segments_area_d = {}
+    bbox_d         = {}
+    region_props_d = {}
+    video_metadata = {}
+
+    for csv_file in csvs:
+        meta = _read_csv_metadata(csv_file, _CSV_HEADER_LINES)
+        if not video_metadata:
+            video_metadata = meta
+
+        df = pd.read_csv(csv_file, skiprows=_CSV_HEADER_LINES)
+        if df.empty:
+            continue
+
+        tid = int(df["track_id"].iloc[0])
+        track_ids.append(tid)
+        labels[tid] = str(df["label"].iloc[0])
+
+        # frame_counter is the first column (MultiIndex level written by to_csv)
+        frame_counters[tid] = df.iloc[:, 0].to_numpy()
+        frame_indices[tid]  = df["frame_idx"].to_numpy()
+        confidence_d[tid]   = df["confidence"].to_numpy()
+        segments_x_d[tid]   = df["pos_x"].to_numpy()
+        segments_y_d[tid]   = df["pos_y"].to_numpy()
+
+        area_col = "area" if "area" in df.columns else None
+        segments_area_d[tid] = (
+            df[area_col].to_numpy() if area_col else np.ones(len(df))
+        )
+
+        bbox_d[tid] = {c: df[c].to_numpy() for c in _BBOX_COLS if c in df.columns}
+
+        # Extra regionprop columns
+        extra_cols = [c for c in df.columns if c not in _BASE_COLS]
+        if isinstance(region_properties, list):
+            extra_cols = [c for c in extra_cols if c in region_properties]
+        # region_properties=None or "all" → keep all extra columns
+        region_props_d[tid] = {c: df[c].to_numpy() for c in extra_cols}
+
+    output_dir = Path(output_dir) if output_dir is not None else predictions_path
+
+    _export_tracking_from_data(
+        output_dir=output_dir,
+        track_ids=track_ids,
+        labels=labels,
+        frame_counters=frame_counters,
+        frame_indices=frame_indices,
+        confidence=confidence_d,
+        segments_x=segments_x_d,
+        segments_y=segments_y_d,
+        segments_area=segments_area_d,
+        bbox=bbox_d,
+        region_props=region_props_d,
+        video_metadata=video_metadata,
+        centroid_method=centroid_method,
+        zarr_root=zarr_root,
+        combined=combined,
+    )

--- a/octron/tools/export_tracking.py
+++ b/octron/tools/export_tracking.py
@@ -465,6 +465,25 @@ _BASE_COLS = frozenset({"frame_counter", "frame_idx", "track_id", "label",
                         "confidence", "pos_x", "pos_y", "area"}) | _BBOX_COLS
 
 
+def list_region_properties(*, print_output: bool = True) -> dict:
+    """Return (and optionally print) all available regionprop names grouped by category.
+
+    Examples
+    --------
+    >>> from octron.tools.export_tracking import list_region_properties
+    >>> props = list_region_properties()
+    """
+    from octron.yolo_octron.constants import ALL_REGION_PROPERTIES
+
+    if print_output:
+        for category, names in ALL_REGION_PROPERTIES.items():
+            print(f"\n{category}:")
+            for name in names:
+                print(f"  {name}")
+        print()
+    return ALL_REGION_PROPERTIES
+
+
 def export_tracking(
     predictions_path,
     output_dir=None,

--- a/octron/tools/export_tracking.py
+++ b/octron/tools/export_tracking.py
@@ -423,6 +423,7 @@ def _export_tracking_from_data(
     method="largest",
     zarr_root=None,
     combined=False,
+    fmt="csv",
 ):
     """
     Build and write tracking CSVs from raw per-track arrays.
@@ -466,6 +467,8 @@ def _export_tracking_from_data(
         Required only when method == "mask_com".
     combined : bool
         True → single all_tracks.csv; False → one file per track.
+    fmt : {"csv", "parquet"}
+        Output format.  Parquet stores video metadata in the file schema.
     """
     import pandas as pd
     from loguru import logger
@@ -566,37 +569,45 @@ def _export_tracking_from_data(
         logger.warning("No tracking data to export.")
         return
 
-    if combined:
-        all_df = pd.concat([df for _, df in dfs.values()]).sort_index()
-        csv_path = output_dir / "all_tracks.csv"
-        tmp_path = csv_path.with_suffix(".tmp")
+    ext = ".parquet" if fmt == "parquet" else ".csv"
+
+    def _write(path, df):
+        tmp = path.with_suffix(".tmp")
         try:
-            with open(tmp_path, "w") as f:
-                f.write(header)
-                all_df.to_csv(f, na_rep="NaN", lineterminator="\n")
-            os.replace(tmp_path, csv_path)
-        except BaseException:
-            tmp_path.unlink(missing_ok=True)
-            raise
-        logger.debug(f"Saved combined tracking data ({len(dfs)} tracks) to all_tracks.csv")
-    else:
-        _WRITE_CHUNK = 5000
-        for tid, (label, df) in tqdm(dfs.items(), desc="Writing CSVs", unit="track", total=len(dfs)):
-            csv_path = output_dir / f"{label}_track_{tid}.csv"
-            tmp_path = csv_path.with_suffix(".tmp")
-            try:
-                with open(tmp_path, "w") as f:
+            if fmt == "parquet":
+                import json
+                import pyarrow as _pa
+                import pyarrow.parquet as _pq
+                table = _pa.Table.from_pandas(df)
+                meta = {**table.schema.metadata,
+                        b"octron_metadata": json.dumps(video_metadata).encode()}
+                _pq.write_table(table.replace_schema_metadata(meta), tmp)
+            else:
+                _WRITE_CHUNK = 5000
+                with open(tmp, "w") as f:
                     f.write(header)
                     chunks = range(0, len(df), _WRITE_CHUNK)
-                    for i in tqdm(chunks, desc=f"  {label}_track_{tid}", unit="chunk", leave=False):
+                    for i in tqdm(chunks, desc=f"  {path.stem}", unit="chunk", leave=False):
                         df.iloc[i : i + _WRITE_CHUNK].to_csv(
                             f, header=(i == 0), na_rep="NaN", lineterminator="\n"
                         )
-                os.replace(tmp_path, csv_path)
-            except BaseException:
-                tmp_path.unlink(missing_ok=True)
-                raise
-            logger.debug(f"Saved tracking data for '{label}' (track ID: {tid}) to {csv_path.name}")
+            os.replace(tmp, path)
+        except BaseException:
+            tmp.unlink(missing_ok=True)
+            raise
+
+    desc = "Writing files" if fmt == "parquet" else "Writing CSVs"
+    if combined:
+        all_df = pd.concat([df for _, df in dfs.values()]).sort_index()
+        out_path = output_dir / f"all_tracks{ext}"
+        tqdm.write(f"Writing combined {fmt} → {out_path.name}")
+        _write(out_path, all_df)
+        logger.debug(f"Saved combined tracking data ({len(dfs)} tracks) to {out_path.name}")
+    else:
+        for tid, (label, df) in tqdm(dfs.items(), desc=desc, unit="track", total=len(dfs)):
+            out_path = output_dir / f"{label}_track_{tid}{ext}"
+            _write(out_path, df)
+            logger.debug(f"Saved tracking data for '{label}' (track ID: {tid}) to {out_path.name}")
 
 
 # ---------------------------------------------------------------------------
@@ -783,6 +794,7 @@ def export_tracking(
     method: Literal["largest", "weighted", "mask_com"] = "largest",
     region_properties=None,
     video_path=None,
+    fmt: Literal["csv", "parquet"] = "csv",
     combined=False,
     overwrite=False,
 ):
@@ -830,8 +842,12 @@ def export_tracking(
         properties (intensity_mean, intensity_max, intensity_min,
         intensity_std).  Auto-detected from the predictions directory name
         if not provided.
+    fmt : {"csv", "parquet"}
+        Output format.  ``"parquet"`` writes a Parquet file per track (or
+        ``all_tracks.parquet`` when *combined* is True); video metadata is
+        stored in the Parquet schema.  Requires ``pyarrow``.
     combined : bool
-        If True write a single ``all_tracks.csv``; otherwise one file per track.
+        If True write a single ``all_tracks.<ext>``; otherwise one file per track.
     overwrite : bool
         If False (default) raise FileExistsError when any output file already
         exists.  Set True to silently overwrite.
@@ -967,18 +983,19 @@ def export_tracking(
     output_dir = Path(output_dir) if output_dir is not None else predictions_path
 
     # --- Overwrite guard ---
+    ext = ".parquet" if fmt == "parquet" else ".csv"
     if not overwrite:
         if combined:
-            candidate = output_dir / "all_tracks.csv"
+            candidate = output_dir / f"all_tracks{ext}"
             if candidate.exists():
                 raise FileExistsError(
                     f"{candidate} already exists. Pass overwrite=True to replace it."
                 )
         else:
             existing = [
-                output_dir / f"{labels[tid]}_track_{tid}.csv"
+                output_dir / f"{labels[tid]}_track_{tid}{ext}"
                 for tid in track_ids
-                if (output_dir / f"{labels[tid]}_track_{tid}.csv").exists()
+                if (output_dir / f"{labels[tid]}_track_{tid}{ext}").exists()
             ]
             if existing:
                 names = ", ".join(p.name for p in existing)
@@ -1004,6 +1021,7 @@ def export_tracking(
         method=method,
         zarr_root=zarr_root,
         combined=combined,
+        fmt=fmt,
     )
     logger.debug(f"export write: {perf_counter()-t6:.3f}s")
     logger.debug(f"total: {perf_counter()-t0:.3f}s")

--- a/octron/tools/export_tracking.py
+++ b/octron/tools/export_tracking.py
@@ -181,7 +181,7 @@ def _zarr_batch_worker(args):
     on Windows (spawn start method).  All imports are local so the worker
     process only loads what it needs.
     """
-    zarr_store_path, arr_key, batch_fi, fi_positions, computable = args
+    zarr_store_path, arr_key, batch_fi, fi_positions, computable, video_path, mask_h, mask_w = args
     import zarr as _zarr
     import numpy as _np
     from skimage import measure as _measure
@@ -196,6 +196,12 @@ def _zarr_batch_worker(args):
     t0 = _pc()
     raw_batch = _np.asarray(zarr_arr[fi_lo : fi_hi + 1])
     t1 = _pc()
+
+    cap = None
+    current_video_pos = -1
+    if video_path is not None:
+        import cv2 as _cv2
+        cap = _cv2.VideoCapture(video_path)
 
     results = {}
     t_binary = t_bbox = t_label = t_props = 0.0
@@ -216,9 +222,25 @@ def _zarr_batch_worker(args):
         c0 = int(cols_any.argmax())
         c1 = int(len(cols_any) - cols_any[::-1].argmax())
         tc = _pc()
+
+        intensity_crop = None
+        if cap is not None:
+            if fi != current_video_pos:
+                cap.set(_cv2.CAP_PROP_POS_FRAMES, fi)
+            ok, frame = cap.read()
+            current_video_pos = fi + 1 if ok else -1
+            if ok:
+                gray = _cv2.cvtColor(frame, _cv2.COLOR_BGR2GRAY)
+                fh, fw = gray.shape
+                if fh != mask_h or fw != mask_w:
+                    gray = _cv2.resize(gray, (mask_w, mask_h), interpolation=_cv2.INTER_LINEAR)
+                intensity_crop = gray[r0:r1, c0:c1]
+
         labeled = _measure.label(binary[r0:r1, c0:c1], background=0, connectivity=2)
         td = _pc()
-        props = _measure.regionprops_table(labeled, properties=computable)
+        props = _measure.regionprops_table(
+            labeled, intensity_image=intensity_crop, properties=computable
+        )
         te = _pc()
 
         t_binary += tb - ta
@@ -237,6 +259,9 @@ def _zarr_batch_worker(args):
             )
         if frame_result:
             results[pos] = frame_result
+
+    if cap is not None:
+        cap.release()
 
     return results, fi_lo, fi_hi, t1 - t0, _pc() - t1, t_binary, t_bbox, t_label, t_props
 
@@ -562,15 +587,12 @@ _BASE_COLS = frozenset({"frame_counter", "frame_idx", "track_id", "label",
 
 
 def compute_region_props_from_zarr(zarr_root, track_ids, frame_indices_dict, properties,
-                                   zarr_path=None):
+                                   zarr_path=None, video_path=None):
     """
     Compute per-frame regionprops directly from zarr segmentation masks.
 
-    Used by :func:`export_tracking` to add shape metrics that were not
-    computed during prediction (i.e. predict was run without ``--detailed``).
-    Intensity properties (intensity_mean etc.) are silently skipped because
-    they require the original video frames; re-run ``octron predict`` with
-    ``--detailed`` if you need them.
+    Used by :func:`export_tracking` to add shape metrics (and optionally
+    intensity metrics) at export time.
 
     Parameters
     ----------
@@ -580,6 +602,12 @@ def compute_region_props_from_zarr(zarr_root, track_ids, frame_indices_dict, pro
         ``{track_id: array of video frame indices}`` matching the CSV rows.
     properties : list[str]
         skimage regionprop base names to compute.
+    zarr_path : Path or None
+        Filesystem path to the zarr store — enables ProcessPoolExecutor.
+    video_path : Path or str or None
+        Path to the original video file.  Required to compute intensity
+        properties (intensity_mean, intensity_max, intensity_min,
+        intensity_std).  Frames are resized to mask resolution if needed.
 
     Returns
     -------
@@ -592,12 +620,16 @@ def compute_region_props_from_zarr(zarr_root, track_ids, frame_indices_dict, pro
     from tqdm import tqdm
     from loguru import logger as _log
 
-    computable = [p for p in properties if p not in _BASE_COLS and p not in _INTENSITY_PROPS]
-    skipped_intensity = [p for p in properties if p in _INTENSITY_PROPS]
+    has_video = video_path is not None
+    computable = [
+        p for p in properties
+        if p not in _BASE_COLS and (has_video or p not in _INTENSITY_PROPS)
+    ]
+    skipped_intensity = [p for p in properties if p in _INTENSITY_PROPS] if not has_video else []
     if skipped_intensity:
         _log.warning(
-            f"Intensity properties {skipped_intensity} cannot be computed from masks "
-            f"alone — re-run 'octron predict' with --detailed to include them."
+            f"Intensity properties {skipped_intensity} require the original video. "
+            f"Pass --video (or video_path=) to compute them."
         )
     if not computable:
         return {}
@@ -625,6 +657,7 @@ def compute_region_props_from_zarr(zarr_root, track_ids, frame_indices_dict, pro
 
         zarr_arr = zarr_root[arr_key]
         n_zarr_frames = zarr_arr.shape[0]
+        mask_h, mask_w = int(zarr_arr.shape[1]), int(zarr_arr.shape[2])
         frame_idxs = np.asarray(frame_indices_dict[tid], dtype=int)
         n = len(frame_idxs)
 
@@ -635,6 +668,8 @@ def compute_region_props_from_zarr(zarr_root, track_ids, frame_indices_dict, pro
         # column names (e.g. moments_hu → moments_hu-0 … moments_hu-6)
         rows = [{} for _ in range(n)]
 
+        _video_path_str = str(video_path) if video_path is not None else None
+
         # Build picklable args for the module-level worker function.
         # Each entry contains everything the worker needs independently.
         batch_args = [
@@ -644,6 +679,9 @@ def compute_region_props_from_zarr(zarr_root, track_ids, frame_indices_dict, pro
                 valid_fi[s : s + _PROPS_BATCH],
                 [fi_to_pos[fi] for fi in valid_fi[s : s + _PROPS_BATCH]],
                 computable,
+                _video_path_str,
+                mask_h,
+                mask_w,
             )
             for s in range(0, len(valid_fi), _PROPS_BATCH)
         ]
@@ -682,6 +720,20 @@ def compute_region_props_from_zarr(zarr_root, track_ids, frame_indices_dict, pro
     return result
 
 
+_VIDEO_EXTENSIONS = (".mp4", ".avi", ".mov", ".mkv", ".mpg", ".mpeg", ".mts", ".m4v")
+
+
+def _autodetect_video(predictions_path: Path):
+    """Replicate YOLO_results auto-detection: strip tracker suffix, look two levels up."""
+    stem = "_".join(predictions_path.name.split("_")[:-1])
+    search_dir = predictions_path.parent.parent
+    for ext in _VIDEO_EXTENSIONS:
+        candidate = search_dir / f"{stem}{ext}"
+        if candidate.exists():
+            return candidate
+    return None
+
+
 def list_region_properties(*, print_output: bool = True) -> dict:
     """Return (and optionally print) all available regionprop names grouped by category.
 
@@ -706,6 +758,7 @@ def export_tracking(
     output_dir=None,
     method: Literal["largest", "weighted", "mask_com"] = "largest",
     region_properties=None,
+    video_path=None,
     combined=False,
     overwrite=False,
 ):
@@ -748,6 +801,11 @@ def export_tracking(
             Include only the named columns that are present in the CSV
             (e.g. ``["eccentricity", "solidity"]``).  Use
             :func:`list_region_properties` to see what is available.
+    video_path : str or Path or None
+        Path to the original video file.  Required to compute intensity
+        properties (intensity_mean, intensity_max, intensity_min,
+        intensity_std).  Auto-detected from the predictions directory name
+        if not provided.
     combined : bool
         If True write a single ``all_tracks.csv``; otherwise one file per track.
     overwrite : bool
@@ -854,21 +912,29 @@ def export_tracking(
 
     logger.debug(f"CSV reading ({len(track_ids)} track(s)): {perf_counter()-t5:.3f}s")
 
+    # --- Auto-detect video if not provided ---
+    if video_path is None:
+        video_path = _autodetect_video(predictions_path)
+        if video_path is not None:
+            logger.info(f"Auto-detected video: {video_path.name}")
+        else:
+            logger.debug("No video file found alongside predictions directory.")
+    else:
+        video_path = Path(video_path)
+
     # --- Compute region props from zarr (always, when zarr is available) ---
     # Zarr masks are the ground truth — always recompute requested props from
     # them rather than relying on CSV values, which may have been produced with
     # a different method or an older version of the pipeline.
     if isinstance(region_properties, list) and zarr_root is not None:
-        props_to_compute = [
-            p for p in region_properties
-            if p not in _BASE_COLS and p not in _INTENSITY_PROPS
-        ]
+        props_to_compute = [p for p in region_properties if p not in _BASE_COLS]
         if props_to_compute:
             logger.info(f"Computing {props_to_compute} from zarr masks...")
             t_zarr = perf_counter()
             zarr_props = compute_region_props_from_zarr(
                 zarr_root, track_ids, frame_indices, props_to_compute,
                 zarr_path=zarr_candidate,
+                video_path=video_path,
             )
             logger.debug(f"zarr regionprops: {perf_counter()-t_zarr:.3f}s")
             for tid in track_ids:

--- a/octron/tools/export_tracking.py
+++ b/octron/tools/export_tracking.py
@@ -162,7 +162,7 @@ def compute_mask_centroids(zarr_root, track_ids, frame_start, frame_end, downsam
 
 
 # ---------------------------------------------------------------------------
-# Region-property constants
+# Region-property constants and per-batch worker (module-level for pickling)
 # ---------------------------------------------------------------------------
 
 # Properties that require the original video frame (intensity image) — cannot
@@ -172,6 +172,71 @@ _INTENSITY_PROPS = frozenset({
 })
 
 _PROPS_BATCH = 500  # zarr frames per contiguous read when computing props
+
+
+def _zarr_batch_worker(args):
+    """Process-pool worker: opens zarr independently and computes regionprops.
+
+    Must be a module-level function so it can be pickled by ProcessPoolExecutor
+    on Windows (spawn start method).  All imports are local so the worker
+    process only loads what it needs.
+    """
+    zarr_store_path, arr_key, batch_fi, fi_positions, computable = args
+    import zarr as _zarr
+    import numpy as _np
+    from skimage import measure as _measure
+    from time import perf_counter as _pc
+    from pathlib import Path as _Path
+
+    store = _zarr.storage.LocalStore(_Path(zarr_store_path), read_only=True)
+    root = _zarr.open_group(store=store, mode="r")
+    zarr_arr = root[arr_key]
+
+    fi_lo, fi_hi = batch_fi[0], batch_fi[-1]
+    t0 = _pc()
+    raw_batch = _np.asarray(zarr_arr[fi_lo : fi_hi + 1])
+    t1 = _pc()
+
+    results = {}
+    t_binary = t_bbox = t_label = t_props = 0.0
+    for fi, pos in zip(batch_fi, fi_positions):
+        raw = raw_batch[fi - fi_lo]
+
+        ta = _pc()
+        binary = (raw == 1).astype(_np.uint8)
+        tb = _pc()
+        rows_nz, cols_nz = _np.where(binary)
+        tc = _pc()
+        if not len(rows_nz):
+            t_binary += tb - ta
+            t_bbox += tc - tb
+            continue
+        r0, r1 = int(rows_nz.min()), int(rows_nz.max()) + 1
+        c0, c1 = int(cols_nz.min()), int(cols_nz.max()) + 1
+        td = _pc()
+        labeled = _measure.label(binary[r0:r1, c0:c1], background=0, connectivity=2)
+        te = _pc()
+        props = _measure.regionprops_table(labeled, properties=computable)
+        tf = _pc()
+
+        t_binary += tb - ta
+        t_bbox += td - tb
+        t_label += te - td
+        t_props += tf - te
+
+        frame_result = {}
+        for col_key, vals in props.items():
+            base = col_key.split("-")[0]
+            if base not in computable and col_key not in computable:
+                continue
+            frame_result[col_key] = (
+                float(vals[0]) if len(vals) == 1
+                else str(tuple(float(v) for v in vals))
+            )
+        if frame_result:
+            results[pos] = frame_result
+
+    return results, fi_lo, fi_hi, t1 - t0, _pc() - t1, t_binary, t_bbox, t_label, t_props
 
 
 # ---------------------------------------------------------------------------
@@ -494,7 +559,8 @@ _BASE_COLS = frozenset({"frame_counter", "frame_idx", "track_id", "label",
                         "confidence", "pos_x", "pos_y", "area"}) | _BBOX_COLS
 
 
-def compute_region_props_from_zarr(zarr_root, track_ids, frame_indices_dict, properties):
+def compute_region_props_from_zarr(zarr_root, track_ids, frame_indices_dict, properties,
+                                   zarr_path=None):
     """
     Compute per-frame regionprops directly from zarr segmentation masks.
 
@@ -535,9 +601,18 @@ def compute_region_props_from_zarr(zarr_root, track_ids, frame_indices_dict, pro
         return {}
 
     import os
-    from concurrent.futures import ThreadPoolExecutor
+    from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor
 
     n_workers = min(8, os.cpu_count() or 4)
+    # ProcessPoolExecutor bypasses the GIL for true CPU parallelism.
+    # Falls back to threads only if the zarr path is unavailable.
+    use_processes = zarr_path is not None
+    ExecutorClass = ProcessPoolExecutor if use_processes else ThreadPoolExecutor
+    _log.debug(
+        f"Using {'ProcessPoolExecutor' if use_processes else 'ThreadPoolExecutor'} "
+        f"with {n_workers} workers"
+    )
+
     result = {}
 
     for tid in tqdm(track_ids, desc="Computing region props from masks", unit="track"):
@@ -553,57 +628,36 @@ def compute_region_props_from_zarr(zarr_root, track_ids, frame_indices_dict, pro
 
         fi_to_pos = {int(fi): i for i, fi in enumerate(frame_idxs)}
         valid_fi = sorted(fi for fi in fi_to_pos if fi < n_zarr_frames)
-        batches = [valid_fi[s : s + _PROPS_BATCH] for s in range(0, len(valid_fi), _PROPS_BATCH)]
 
         # per-frame result as list-of-dicts — handles dynamically-expanded
         # column names (e.g. moments_hu → moments_hu-0 … moments_hu-6)
         rows = [{} for _ in range(n)]
 
-        def _process_batch(batch):
-            fi_lo, fi_hi = batch[0], batch[-1]
-            t_io = perf_counter()
-            raw_batch = np.asarray(zarr_arr[fi_lo : fi_hi + 1])
-            t_io_done = perf_counter()
-            batch_results = {}
-            for fi in batch:
-                raw = raw_batch[fi - fi_lo]
-                binary = (raw == 1).astype(np.uint8)
-                rows_nz, cols_nz = np.where(binary)
-                if len(rows_nz) == 0:
-                    continue
-                # Crop to bounding box — all requested props are translation-
-                # invariant so results are identical to full-image computation
-                # but on ~100x fewer pixels (e.g. 50×50 vs 640×640).
-                r0, r1 = rows_nz.min(), rows_nz.max() + 1
-                c0, c1 = cols_nz.min(), cols_nz.max() + 1
-                crop = binary[r0:r1, c0:c1]
-                labeled = measure.label(crop, background=0, connectivity=2)
-                props = measure.regionprops_table(labeled, properties=computable)
-                frame_result = {}
-                for col_key, vals in props.items():
-                    base = col_key.split("-")[0]
-                    if base not in computable and col_key not in computable:
-                        continue
-                    frame_result[col_key] = (
-                        float(vals[0]) if len(vals) == 1
-                        else str(tuple(float(v) for v in vals))
-                    )
-                if frame_result:
-                    batch_results[fi_to_pos[fi]] = frame_result
-            t_cpu_done = perf_counter()
-            _log.debug(
-                f"batch {fi_lo}-{fi_hi}: "
-                f"zarr_read={t_io_done - t_io:.3f}s  "
-                f"regionprops={t_cpu_done - t_io_done:.3f}s"
+        # Build picklable args for the module-level worker function.
+        # Each entry contains everything the worker needs independently.
+        batch_args = [
+            (
+                str(zarr_path),
+                arr_key,
+                valid_fi[s : s + _PROPS_BATCH],
+                [fi_to_pos[fi] for fi in valid_fi[s : s + _PROPS_BATCH]],
+                computable,
             )
-            return batch_results
+            for s in range(0, len(valid_fi), _PROPS_BATCH)
+        ]
 
-        with ThreadPoolExecutor(max_workers=n_workers) as executor:
-            for batch_results in tqdm(
-                executor.map(_process_batch, batches),
-                total=len(batches),
+        with ExecutorClass(max_workers=n_workers) as executor:
+            for batch_results, fi_lo, fi_hi, t_io, t_cpu, t_bin, t_bbox, t_lbl, t_rpt in tqdm(
+                executor.map(_zarr_batch_worker, batch_args),
+                total=len(batch_args),
                 desc=f"  track {tid}", unit="batch", leave=False,
             ):
+                _log.debug(
+                    f"batch {fi_lo}-{fi_hi}: zarr_read={t_io:.3f}s  "
+                    f"regionprops={t_cpu:.3f}s "
+                    f"(binary={t_bin:.3f}s  bbox={t_bbox:.3f}s  "
+                    f"label={t_lbl:.3f}s  props_table={t_rpt:.3f}s)"
+                )
                 for pos, frame_result in batch_results.items():
                     rows[pos].update(frame_result)
 
@@ -811,7 +865,8 @@ def export_tracking(
             logger.info(f"Computing {props_to_compute} from zarr masks...")
             t_zarr = perf_counter()
             zarr_props = compute_region_props_from_zarr(
-                zarr_root, track_ids, frame_indices, props_to_compute
+                zarr_root, track_ids, frame_indices, props_to_compute,
+                zarr_path=zarr_candidate,
             )
             logger.debug(f"zarr regionprops: {perf_counter()-t_zarr:.3f}s")
             for tid in track_ids:

--- a/octron/tools/export_tracking.py
+++ b/octron/tools/export_tracking.py
@@ -568,9 +568,16 @@ def compute_region_props_from_zarr(zarr_root, track_ids, frame_indices_dict, pro
             for fi in batch:
                 raw = raw_batch[fi - fi_lo]
                 binary = (raw == 1).astype(np.uint8)
-                if binary.sum() == 0:
+                rows_nz, cols_nz = np.where(binary)
+                if len(rows_nz) == 0:
                     continue
-                labeled = measure.label(binary, background=0, connectivity=2)
+                # Crop to bounding box — all requested props are translation-
+                # invariant so results are identical to full-image computation
+                # but on ~100x fewer pixels (e.g. 50×50 vs 640×640).
+                r0, r1 = rows_nz.min(), rows_nz.max() + 1
+                c0, c1 = cols_nz.min(), cols_nz.max() + 1
+                crop = binary[r0:r1, c0:c1]
+                labeled = measure.label(crop, background=0, connectivity=2)
                 props = measure.regionprops_table(labeled, properties=computable)
                 frame_result = {}
                 for col_key, vals in props.items():

--- a/octron/tools/export_tracking.py
+++ b/octron/tools/export_tracking.py
@@ -580,13 +580,18 @@ def _export_tracking_from_data(
             raise
         logger.debug(f"Saved combined tracking data ({len(dfs)} tracks) to all_tracks.csv")
     else:
+        _WRITE_CHUNK = 5000
         for tid, (label, df) in tqdm(dfs.items(), desc="Writing CSVs", unit="track", total=len(dfs)):
             csv_path = output_dir / f"{label}_track_{tid}.csv"
             tmp_path = csv_path.with_suffix(".tmp")
             try:
                 with open(tmp_path, "w") as f:
                     f.write(header)
-                    df.to_csv(f, na_rep="NaN", lineterminator="\n")
+                    chunks = range(0, len(df), _WRITE_CHUNK)
+                    for i in tqdm(chunks, desc=f"  {label}_track_{tid}", unit="chunk", leave=False):
+                        df.iloc[i : i + _WRITE_CHUNK].to_csv(
+                            f, header=(i == 0), na_rep="NaN", lineterminator="\n"
+                        )
                 os.replace(tmp_path, csv_path)
             except BaseException:
                 tmp_path.unlink(missing_ok=True)

--- a/octron/tools/export_tracking.py
+++ b/octron/tools/export_tracking.py
@@ -167,6 +167,9 @@ def compute_mask_centroids(zarr_root, track_ids, frame_start, frame_end, downsam
 
 # Properties that require the original video frame (intensity image) — cannot
 # be computed from masks alone at export time.
+# When a video is provided, these are computed on a 4-channel image
+# (R, G, B, luminance), so each property expands to four columns:
+#   intensity_mean-0 = R,  -1 = G,  -2 = B,  -3 = luminance
 _INTENSITY_PROPS = frozenset({
     "intensity_max", "intensity_mean", "intensity_min", "intensity_std",
 })
@@ -230,11 +233,14 @@ def _zarr_batch_worker(args):
             ok, frame = cap.read()
             current_video_pos = fi + 1 if ok else -1
             if ok:
-                gray = _cv2.cvtColor(frame, _cv2.COLOR_BGR2GRAY)
-                fh, fw = gray.shape
+                # Resize to mask resolution if needed
+                fh, fw = frame.shape[:2]
                 if fh != mask_h or fw != mask_w:
-                    gray = _cv2.resize(gray, (mask_w, mask_h), interpolation=_cv2.INTER_LINEAR)
-                intensity_crop = gray[r0:r1, c0:c1]
+                    frame = _cv2.resize(frame, (mask_w, mask_h), interpolation=_cv2.INTER_LINEAR)
+                # Channels: 0=R, 1=G, 2=B, 3=luminance
+                rgb = _cv2.cvtColor(frame, _cv2.COLOR_BGR2RGB)
+                lum = _cv2.cvtColor(frame, _cv2.COLOR_BGR2GRAY)
+                intensity_crop = _np.dstack([rgb, lum])[r0:r1, c0:c1]
 
         labeled = _measure.label(binary[r0:r1, c0:c1], background=0, connectivity=2)
         td = _pc()

--- a/octron/tools/export_tracking.py
+++ b/octron/tools/export_tracking.py
@@ -37,6 +37,7 @@ compute_mask_centroids : Compute per-frame centre-of-mass from zarr masks.
 import ast
 from datetime import datetime
 from pathlib import Path
+from time import perf_counter
 from typing import Literal
 
 import numpy as np
@@ -533,22 +534,34 @@ def export_tracking(
         If False (default) raise FileExistsError when any output file already
         exists.  Set True to silently overwrite.
     """
+    t0 = perf_counter()
+    from loguru import logger
+    logger.debug(f"loguru import: {perf_counter()-t0:.3f}s")
+
+    t1 = perf_counter()
     import zarr
+    logger.debug(f"zarr import: {perf_counter()-t1:.3f}s")
+
+    t2 = perf_counter()
     from natsort import natsorted
     import pandas as pd
-    from loguru import logger
+    logger.debug(f"natsort+pandas import: {perf_counter()-t2:.3f}s")
 
     predictions_path = Path(predictions_path)
 
     # --- Discover CSV files ---
+    t3 = perf_counter()
     csvs = natsorted(predictions_path.rglob("*track_*.csv"))
+    logger.debug(f"CSV discovery (rglob): {perf_counter()-t3:.3f}s")
     if not csvs:
         raise FileNotFoundError(f"No tracking CSV files found in {predictions_path}")
     logger.info(f"Found {len(csvs)} tracking CSV(s) in {predictions_path.name}")
 
     # --- Discover zarr (optional; required only for mask_com) ---
+    t4 = perf_counter()
     zarr_root = None
     zarr_paths = list(predictions_path.rglob("predictions.zarr"))
+    logger.debug(f"zarr discovery (rglob): {perf_counter()-t4:.3f}s")
     if zarr_paths:
         store = zarr.storage.LocalStore(zarr_paths[0], read_only=True)
         zarr_root = zarr.open_group(store=store, mode="r")
@@ -567,6 +580,7 @@ def export_tracking(
         region_properties = list(ALL_REGION_PROPERTIES[_GROUP_ALIASES[region_properties]])
 
     # --- Read each CSV ---
+    t5 = perf_counter()
     track_ids      = []
     labels         = {}
     frame_counters = {}
@@ -615,6 +629,7 @@ def export_tracking(
         # region_properties=None or "all" → keep all extra columns
         region_props_d[tid] = {c: df[c].to_numpy() for c in extra_cols}
 
+    logger.debug(f"CSV reading ({len(track_ids)} track(s)): {perf_counter()-t5:.3f}s")
     output_dir = Path(output_dir) if output_dir is not None else predictions_path
 
     # --- Overwrite guard ---
@@ -638,6 +653,7 @@ def export_tracking(
                     "Pass overwrite=True to replace them."
                 )
 
+    t6 = perf_counter()
     _export_tracking_from_data(
         output_dir=output_dir,
         track_ids=track_ids,
@@ -655,3 +671,5 @@ def export_tracking(
         zarr_root=zarr_root,
         combined=combined,
     )
+    logger.debug(f"export write: {perf_counter()-t6:.3f}s")
+    logger.debug(f"total: {perf_counter()-t0:.3f}s")

--- a/octron/tools/export_tracking.py
+++ b/octron/tools/export_tracking.py
@@ -35,6 +35,7 @@ compute_mask_centroids : Compute per-frame centre-of-mass from zarr masks.
 """
 
 import ast
+import os
 from datetime import datetime
 from pathlib import Path
 from time import perf_counter
@@ -444,16 +445,28 @@ def _export_tracking_from_data(
     if combined:
         all_df = pd.concat([df for _, df in dfs.values()]).sort_index()
         csv_path = output_dir / "all_tracks.csv"
-        with open(csv_path, "w") as f:
-            f.write(header)
-            all_df.to_csv(f, na_rep="NaN", lineterminator="\n")
+        tmp_path = csv_path.with_suffix(".tmp")
+        try:
+            with open(tmp_path, "w") as f:
+                f.write(header)
+                all_df.to_csv(f, na_rep="NaN", lineterminator="\n")
+            os.replace(tmp_path, csv_path)
+        except BaseException:
+            tmp_path.unlink(missing_ok=True)
+            raise
         logger.debug(f"Saved combined tracking data ({len(dfs)} tracks) to all_tracks.csv")
     else:
         for tid, (label, df) in tqdm(dfs.items(), desc="Writing CSVs", unit="track", total=len(dfs)):
             csv_path = output_dir / f"{label}_track_{tid}.csv"
-            with open(csv_path, "w") as f:
-                f.write(header)
-                df.to_csv(f, na_rep="NaN", lineterminator="\n")
+            tmp_path = csv_path.with_suffix(".tmp")
+            try:
+                with open(tmp_path, "w") as f:
+                    f.write(header)
+                    df.to_csv(f, na_rep="NaN", lineterminator="\n")
+                os.replace(tmp_path, csv_path)
+            except BaseException:
+                tmp_path.unlink(missing_ok=True)
+                raise
             logger.debug(f"Saved tracking data for '{label}' (track ID: {tid}) to {csv_path.name}")
 
 

--- a/octron/tools/export_tracking.py
+++ b/octron/tools/export_tracking.py
@@ -404,6 +404,61 @@ def _read_csv_metadata(csv_path, n_header_lines=7):
 
 
 # ---------------------------------------------------------------------------
+# Column ordering
+# ---------------------------------------------------------------------------
+
+_COL_BASE = [
+    "label", "confidence", "pos_x", "pos_y",
+    "bbox_x_min", "bbox_x_max", "bbox_y_min", "bbox_y_max",
+    "bbox_area", "bbox_aspect_ratio", "area",
+]
+_CHANNEL_SUFFIXES = ("_r", "_g", "_b", "_lum")
+
+
+def _ordered_columns(df_columns):
+    """Return df_columns in canonical order.
+
+    Order: base cols → shape props → intensity props (ALL_REGION_PROPERTIES
+    order).  Multi-value expansions (moments_hu-0 … -6) and channel
+    expansions (intensity_mean_r/g/b/lum) are grouped immediately after
+    their base name.  Unknown columns follow at the end.
+    """
+    from octron.yolo_octron.constants import ALL_REGION_PROPERTIES
+
+    known_props = [
+        p for group in ALL_REGION_PROPERTIES.values() for p in group
+        if p != "area"  # area is already in _COL_BASE
+    ]
+
+    cols = set(df_columns)
+    result = []
+    seen = set()
+
+    def _add(c):
+        if c in cols and c not in seen:
+            result.append(c)
+            seen.add(c)
+
+    def _add_with_expansions(prop):
+        _add(prop)
+        for c in sorted(c for c in cols if c.startswith(prop + "-")):
+            _add(c)
+        for suf in _CHANNEL_SUFFIXES:
+            _add(prop + suf)
+
+    for col in _COL_BASE:
+        _add(col)
+
+    for prop in known_props:
+        _add_with_expansions(prop)
+
+    for c in df_columns:  # anything not yet placed
+        _add(c)
+
+    return result
+
+
+# ---------------------------------------------------------------------------
 # Private core function
 # ---------------------------------------------------------------------------
 
@@ -563,7 +618,9 @@ def _export_tracking_from_data(
             ],
             names=["frame_counter", "frame_idx", "track_id"],
         )
-        dfs[tid] = (label, pd.DataFrame(data, index=idx))
+        df = pd.DataFrame(data, index=idx)
+        df = df[_ordered_columns(df.columns)]
+        dfs[tid] = (label, df)
 
     if not dfs:
         logger.warning("No tracking data to export.")

--- a/octron/tools/export_tracking.py
+++ b/octron/tools/export_tracking.py
@@ -527,7 +527,10 @@ def _export_tracking_from_data(
 
         # --- all other regionprops ---
         resolved_props = {}
-        for prop_name, prop_values in (region_props.get(tid) or {}).items():
+        prop_items = list((region_props.get(tid) or {}).items())
+        for prop_name, prop_values in tqdm(
+            prop_items, desc=f"  resolving props", unit="prop", leave=False,
+        ):
             pv = np.asarray(prop_values, dtype=object)
             # orientation is a circular quantity — always use largest segment.
             if prop_name == "orientation" or not _use_weighted:

--- a/octron/tools/export_tracking.py
+++ b/octron/tools/export_tracking.py
@@ -6,7 +6,7 @@ into clean, analysis-ready CSV files with resolved scalar columns.
 
 All columns that contain tuple-strings (produced when multiple disconnected
 segments are detected in a single frame) are resolved to scalars using the
-chosen ``centroid_method``.  The same strategy applies to every column —
+chosen ``method``.  The same strategy applies to every column —
 positions, areas, shape descriptors, and intensity properties — so the output
 is always fully numeric.
 
@@ -162,6 +162,19 @@ def compute_mask_centroids(zarr_root, track_ids, frame_start, frame_end, downsam
 
 
 # ---------------------------------------------------------------------------
+# Region-property constants
+# ---------------------------------------------------------------------------
+
+# Properties that require the original video frame (intensity image) — cannot
+# be computed from masks alone at export time.
+_INTENSITY_PROPS = frozenset({
+    "intensity_max", "intensity_mean", "intensity_min", "intensity_std",
+})
+
+_PROPS_BATCH = 100  # zarr frames per contiguous read when computing props
+
+
+# ---------------------------------------------------------------------------
 # Tuple-resolution helpers
 # ---------------------------------------------------------------------------
 
@@ -299,7 +312,7 @@ def _export_tracking_from_data(
     bbox,
     region_props,
     video_metadata,
-    centroid_method="largest",
+    method="largest",
     zarr_root=None,
     combined=False,
 ):
@@ -310,7 +323,7 @@ def _export_tracking_from_data(
     both ``predict_batch`` (in-memory path) and ``export_tracking`` (disk path).
 
     All tuple-valued columns (produced when multiple disconnected segments are
-    detected in a frame) are resolved to scalars using ``centroid_method``.
+    detected in a frame) are resolved to scalars using ``method``.
     The same strategy applies to positions, areas, and all regionprops columns,
     with two exceptions:
 
@@ -340,9 +353,9 @@ def _export_tracking_from_data(
     video_metadata : dict
         Keys: video_name, frame_count, frame_count_analyzed,
               video_height, video_width, created_at.
-    centroid_method : {"largest", "weighted", "mask_com"}
+    method : {"largest", "weighted", "mask_com"}
     zarr_root : zarr.Group or None
-        Required only when centroid_method == "mask_com".
+        Required only when method == "mask_com".
     combined : bool
         True → single all_tracks.csv; False → one file per track.
     """
@@ -354,7 +367,7 @@ def _export_tracking_from_data(
 
     # Pre-compute mask centroids once across all tracks when needed
     mask_centroids_lookup = {}
-    if centroid_method == "mask_com" and zarr_root is not None:
+    if method == "mask_com" and zarr_root is not None:
         all_frames = [int(f) for tid in track_ids for f in frame_indices.get(tid, [])]
         if all_frames:
             print("Computing mask centroids from zarr...")
@@ -364,9 +377,9 @@ def _export_tracking_from_data(
                 frame_end=max(all_frames) + 1,
             )
 
-    # Determine per-prop resolver based on centroid_method.
+    # Determine per-prop resolver based on method.
     # mask_com falls back to weighted for all non-centroid metrics.
-    _use_weighted = centroid_method in ("weighted", "mask_com")
+    _use_weighted = method in ("weighted", "mask_com")
 
     from tqdm import tqdm
 
@@ -385,9 +398,9 @@ def _export_tracking_from_data(
         sa = np.asarray(segments_area.get(tid, np.ones(n)), dtype=object)
 
         # --- pos_x / pos_y ---
-        if centroid_method == "weighted":
+        if method == "weighted":
             px, py = _resolve_xy_weighted(sx, sy, sa)
-        elif centroid_method == "mask_com" and mask_centroids_lookup.get(tid):
+        elif method == "mask_com" and mask_centroids_lookup.get(tid):
             fi_arr = np.asarray(frame_indices[tid])
             lookup = mask_centroids_lookup[tid]
             px = np.array([lookup.get(int(f), (np.nan, np.nan))[0] for f in fi_arr])
@@ -481,6 +494,111 @@ _BASE_COLS = frozenset({"frame_counter", "frame_idx", "track_id", "label",
                         "confidence", "pos_x", "pos_y", "area"}) | _BBOX_COLS
 
 
+def compute_region_props_from_zarr(zarr_root, track_ids, frame_indices_dict, properties):
+    """
+    Compute per-frame regionprops directly from zarr segmentation masks.
+
+    Used by :func:`export_tracking` to add shape metrics that were not
+    computed during prediction (i.e. predict was run without ``--detailed``).
+    Intensity properties (intensity_mean etc.) are silently skipped because
+    they require the original video frames; re-run ``octron predict`` with
+    ``--detailed`` if you need them.
+
+    Parameters
+    ----------
+    zarr_root : zarr.Group
+    track_ids : list[int]
+    frame_indices_dict : dict[int, array-like]
+        ``{track_id: array of video frame indices}`` matching the CSV rows.
+    properties : list[str]
+        skimage regionprop base names to compute.
+
+    Returns
+    -------
+    dict[int, dict[str, np.ndarray]]
+        ``{track_id: {col_name: per-frame array}}``.
+        Multi-segment frames are encoded as tuple-strings ``"(v1, v2, ...)"``.
+        Empty-mask frames are ``NaN``.
+    """
+    from skimage import measure
+    from tqdm import tqdm
+    from loguru import logger as _log
+
+    computable = [p for p in properties if p not in _BASE_COLS and p not in _INTENSITY_PROPS]
+    skipped_intensity = [p for p in properties if p in _INTENSITY_PROPS]
+    if skipped_intensity:
+        _log.warning(
+            f"Intensity properties {skipped_intensity} cannot be computed from masks "
+            f"alone — re-run 'octron predict' with --detailed to include them."
+        )
+    if not computable:
+        return {}
+
+    result = {}
+
+    for tid in tqdm(track_ids, desc="Computing region props from masks", unit="track"):
+        arr_key = f"{tid}_masks"
+        if arr_key not in zarr_root:
+            _log.warning(f"No mask array found in zarr for track {tid} — skipping.")
+            continue
+
+        zarr_arr = zarr_root[arr_key]
+        n_zarr_frames = zarr_arr.shape[0]
+        frame_idxs = np.asarray(frame_indices_dict[tid], dtype=int)
+        n = len(frame_idxs)
+
+        fi_to_pos = {int(fi): i for i, fi in enumerate(frame_idxs)}
+        valid_fi = sorted(fi for fi in fi_to_pos if fi < n_zarr_frames)
+
+        # per-frame result as list-of-dicts — handles dynamically-expanded
+        # column names (e.g. moments_hu → moments_hu-0 … moments_hu-6)
+        rows = [{} for _ in range(n)]
+
+        for b_start in tqdm(range(0, len(valid_fi), _PROPS_BATCH),
+                            desc=f"  track {tid}", unit="batch", leave=False):
+            batch = valid_fi[b_start : b_start + _PROPS_BATCH]
+            fi_lo, fi_hi = batch[0], batch[-1]
+            # One contiguous zarr read per batch — minimises network round-trips
+            raw_batch = np.asarray(zarr_arr[fi_lo : fi_hi + 1])  # (span, H, W)
+
+            for fi in batch:
+                raw = raw_batch[fi - fi_lo]
+                binary = (raw == 1).astype(np.uint8)
+                if binary.sum() == 0:
+                    continue
+
+                labeled = measure.label(binary, background=0, connectivity=2)
+                props = measure.regionprops_table(labeled, properties=computable)
+
+                pos = fi_to_pos[fi]
+                for col_key, vals in props.items():
+                    base = col_key.split("-")[0]
+                    if base not in computable and col_key not in computable:
+                        continue
+                    if len(vals) == 1:
+                        rows[pos][col_key] = float(vals[0])
+                    else:
+                        rows[pos][col_key] = str(tuple(float(v) for v in vals))
+
+        # Collect all column names that actually appeared (handles expansion)
+        all_keys = set()
+        for row in rows:
+            all_keys.update(row.keys())
+
+        tid_result = {}
+        for col_key in all_keys:
+            arr = np.empty(n, dtype=object)
+            arr[:] = np.nan
+            for i, row in enumerate(rows):
+                if col_key in row:
+                    arr[i] = row[col_key]
+            tid_result[col_key] = arr
+
+        result[tid] = tid_result
+
+    return result
+
+
 def list_region_properties(*, print_output: bool = True) -> dict:
     """Return (and optionally print) all available regionprop names grouped by category.
 
@@ -503,7 +621,7 @@ def list_region_properties(*, print_output: bool = True) -> dict:
 def export_tracking(
     predictions_path,
     output_dir=None,
-    centroid_method: Literal["largest", "weighted", "mask_com"] = "largest",
+    method: Literal["largest", "weighted", "mask_com"] = "largest",
     region_properties=None,
     combined=False,
     overwrite=False,
@@ -521,14 +639,18 @@ def export_tracking(
         Path to an ``octron_predictions/<video>/`` output directory.
     output_dir : str or Path or None
         Where to write the output CSVs.  Defaults to *predictions_path*.
-    centroid_method : {"largest", "weighted", "mask_com"}
+    method : {"largest", "weighted", "mask_com"}
         How to resolve multi-segment rows.  Applied consistently to all
         columns (positions, areas, regionprops).  See module docstring.
     region_properties : None, "all", "none", "shape", "intensity", or list[str]
         Which regionprop columns to include in the output.
 
-        ``None`` / ``"all"``
-            Keep every regionprop column found in the existing CSV (default).
+        ``None``
+            Keep every regionprop column already present in the CSV (default).
+            No zarr computation is performed.
+        ``"all"``
+            Compute every property from all groups in ``ALL_REGION_PROPERTIES``
+            (equivalent to ``"shape"`` + ``"intensity"``).
         ``"none"``
             Strip all regionprop columns; output contains only the base
             columns (frame counters, track id, label, confidence, pos_x/y,
@@ -581,16 +703,19 @@ def export_tracking(
         store = zarr.storage.LocalStore(zarr_candidate, read_only=True)
         zarr_root = zarr.open_group(store=store, mode="r")
         logger.info("Found zarr archive")
-    elif centroid_method == "mask_com":
+    elif method == "mask_com":
         logger.warning(
-            "centroid_method='mask_com' requested but no zarr archive found — "
+            "method='mask_com' requested but no zarr archive found — "
             "falling back to 'largest'."
         )
-        centroid_method = "largest"
+        method = "largest"
 
     # --- Resolve region_properties group aliases ---
     _GROUP_ALIASES = {"shape": "Size and Shape", "intensity": "Intensity"}
-    if isinstance(region_properties, str) and region_properties in _GROUP_ALIASES:
+    if region_properties == "all":
+        from octron.yolo_octron.constants import ALL_REGION_PROPERTIES
+        region_properties = [p for props in ALL_REGION_PROPERTIES.values() for p in props]
+    elif isinstance(region_properties, str) and region_properties in _GROUP_ALIASES:
         from octron.yolo_octron.constants import ALL_REGION_PROPERTIES
         region_properties = list(ALL_REGION_PROPERTIES[_GROUP_ALIASES[region_properties]])
 
@@ -641,10 +766,30 @@ def export_tracking(
             extra_cols = []
         elif isinstance(region_properties, list):
             extra_cols = [c for c in extra_cols if c in region_properties]
-        # region_properties=None or "all" → keep all extra columns
+        # region_properties=None → keep all extra columns already in the CSV
         region_props_d[tid] = {c: df[c].to_numpy() for c in extra_cols}
 
     logger.debug(f"CSV reading ({len(track_ids)} track(s)): {perf_counter()-t5:.3f}s")
+
+    # --- Compute region props from zarr (always, when zarr is available) ---
+    # Zarr masks are the ground truth — always recompute requested props from
+    # them rather than relying on CSV values, which may have been produced with
+    # a different method or an older version of the pipeline.
+    if isinstance(region_properties, list) and zarr_root is not None:
+        props_to_compute = [
+            p for p in region_properties
+            if p not in _BASE_COLS and p not in _INTENSITY_PROPS
+        ]
+        if props_to_compute:
+            logger.info(f"Computing {props_to_compute} from zarr masks...")
+            t_zarr = perf_counter()
+            zarr_props = compute_region_props_from_zarr(
+                zarr_root, track_ids, frame_indices, props_to_compute
+            )
+            logger.debug(f"zarr regionprops: {perf_counter()-t_zarr:.3f}s")
+            for tid in track_ids:
+                region_props_d.setdefault(tid, {}).update(zarr_props.get(tid, {}))
+
     output_dir = Path(output_dir) if output_dir is not None else predictions_path
 
     # --- Overwrite guard ---
@@ -682,7 +827,7 @@ def export_tracking(
         bbox=bbox_d,
         region_props=region_props_d,
         video_metadata=video_metadata,
-        centroid_method=centroid_method,
+        method=method,
         zarr_root=zarr_root,
         combined=combined,
     )

--- a/octron/tools/export_tracking.py
+++ b/octron/tools/export_tracking.py
@@ -551,8 +551,8 @@ def export_tracking(
 
     # --- Discover CSV files ---
     t3 = perf_counter()
-    csvs = natsorted(predictions_path.rglob("*track_*.csv"))
-    logger.debug(f"CSV discovery (rglob): {perf_counter()-t3:.3f}s")
+    csvs = natsorted(predictions_path.glob("*track_*.csv"))
+    logger.debug(f"CSV discovery: {perf_counter()-t3:.3f}s")
     if not csvs:
         raise FileNotFoundError(f"No tracking CSV files found in {predictions_path}")
     logger.info(f"Found {len(csvs)} tracking CSV(s) in {predictions_path.name}")
@@ -560,10 +560,10 @@ def export_tracking(
     # --- Discover zarr (optional; required only for mask_com) ---
     t4 = perf_counter()
     zarr_root = None
-    zarr_paths = list(predictions_path.rglob("predictions.zarr"))
-    logger.debug(f"zarr discovery (rglob): {perf_counter()-t4:.3f}s")
-    if zarr_paths:
-        store = zarr.storage.LocalStore(zarr_paths[0], read_only=True)
+    zarr_candidate = predictions_path / "predictions.zarr"
+    logger.debug(f"zarr discovery: {perf_counter()-t4:.3f}s")
+    if zarr_candidate.exists():
+        store = zarr.storage.LocalStore(zarr_candidate, read_only=True)
         zarr_root = zarr.open_group(store=store, mode="r")
         logger.info("Found zarr archive")
     elif centroid_method == "mask_com":

--- a/octron/tools/export_tracking.py
+++ b/octron/tools/export_tracking.py
@@ -471,6 +471,7 @@ def export_tracking(
     centroid_method: Literal["largest", "weighted", "mask_com"] = "largest",
     region_properties=None,
     combined=False,
+    overwrite=False,
 ):
     """
     Export tracking CSVs from an existing OCTRON predictions directory.
@@ -494,6 +495,9 @@ def export_tracking(
         A list of names → include only those columns (if present in the CSV).
     combined : bool
         If True write a single ``all_tracks.csv``; otherwise one file per track.
+    overwrite : bool
+        If False (default) raise FileExistsError when any output file already
+        exists.  Set True to silently overwrite.
     """
     import zarr
     from natsort import natsorted
@@ -570,6 +574,27 @@ def export_tracking(
         region_props_d[tid] = {c: df[c].to_numpy() for c in extra_cols}
 
     output_dir = Path(output_dir) if output_dir is not None else predictions_path
+
+    # --- Overwrite guard ---
+    if not overwrite:
+        if combined:
+            candidate = output_dir / "all_tracks.csv"
+            if candidate.exists():
+                raise FileExistsError(
+                    f"{candidate} already exists. Pass overwrite=True to replace it."
+                )
+        else:
+            existing = [
+                output_dir / f"{labels[tid]}_track_{tid}.csv"
+                for tid in track_ids
+                if (output_dir / f"{labels[tid]}_track_{tid}.csv").exists()
+            ]
+            if existing:
+                names = ", ".join(p.name for p in existing)
+                raise FileExistsError(
+                    f"Output file(s) already exist: {names}. "
+                    "Pass overwrite=True to replace them."
+                )
 
     _export_tracking_from_data(
         output_dir=output_dir,

--- a/octron/tools/export_tracking.py
+++ b/octron/tools/export_tracking.py
@@ -169,10 +169,14 @@ def compute_mask_centroids(zarr_root, track_ids, frame_start, frame_end, downsam
 # be computed from masks alone at export time.
 # When a video is provided, these are computed on a 4-channel image
 # (R, G, B, luminance), so each property expands to four columns:
-#   intensity_mean-0 = R,  -1 = G,  -2 = B,  -3 = luminance
+#   intensity_mean_r, intensity_mean_g, intensity_mean_b, intensity_mean_lum
 _INTENSITY_PROPS = frozenset({
     "intensity_max", "intensity_mean", "intensity_min", "intensity_std",
 })
+
+# Rename skimage's numeric channel suffixes to readable labels.
+# Channels are stacked as (R, G, B, luminance) in the worker.
+_CHANNEL_SUFFIX = {"-0": "_r", "-1": "_g", "-2": "_b", "-3": "_lum"}
 
 _PROPS_BATCH = 500  # zarr frames per contiguous read when computing props
 
@@ -255,11 +259,17 @@ def _zarr_batch_worker(args):
         t_props += te - td
 
         frame_result = {}
+        _ch = {"-0": "_r", "-1": "_g", "-2": "_b", "-3": "_lum"}
         for col_key, vals in props.items():
             base = col_key.split("-")[0]
             if base not in computable and col_key not in computable:
                 continue
-            frame_result[col_key] = (
+            out_key = col_key
+            for old_suf, new_suf in _ch.items():
+                if col_key.endswith(old_suf):
+                    out_key = col_key[: -len(old_suf)] + new_suf
+                    break
+            frame_result[out_key] = (
                 float(vals[0]) if len(vals) == 1
                 else str(tuple(float(v) for v in vals))
             )

--- a/octron/tools/export_tracking.py
+++ b/octron/tools/export_tracking.py
@@ -508,7 +508,7 @@ def export_tracking(
     centroid_method : {"largest", "weighted", "mask_com"}
         How to resolve multi-segment rows.  Applied consistently to all
         columns (positions, areas, regionprops).  See module docstring.
-    region_properties : None, "all", "none", or list[str]
+    region_properties : None, "all", "none", "shape", "intensity", or list[str]
         Which regionprop columns to include in the output.
 
         ``None`` / ``"all"``
@@ -517,6 +517,12 @@ def export_tracking(
             Strip all regionprop columns; output contains only the base
             columns (frame counters, track id, label, confidence, pos_x/y,
             area, bbox).
+        ``"shape"``
+            Include only the size-and-shape group (area, eccentricity,
+            solidity, etc.).
+        ``"intensity"``
+            Include only the intensity group (intensity_mean, intensity_max,
+            intensity_min, intensity_std).
         list of strings
             Include only the named columns that are present in the CSV
             (e.g. ``["eccentricity", "solidity"]``).  Use
@@ -553,6 +559,12 @@ def export_tracking(
             "falling back to 'largest'."
         )
         centroid_method = "largest"
+
+    # --- Resolve region_properties group aliases ---
+    _GROUP_ALIASES = {"shape": "Size and Shape", "intensity": "Intensity"}
+    if isinstance(region_properties, str) and region_properties in _GROUP_ALIASES:
+        from octron.yolo_octron.constants import ALL_REGION_PROPERTIES
+        region_properties = list(ALL_REGION_PROPERTIES[_GROUP_ALIASES[region_properties]])
 
     # --- Read each CSV ---
     track_ids      = []

--- a/octron/tools/export_tracking.py
+++ b/octron/tools/export_tracking.py
@@ -508,10 +508,19 @@ def export_tracking(
     centroid_method : {"largest", "weighted", "mask_com"}
         How to resolve multi-segment rows.  Applied consistently to all
         columns (positions, areas, regionprops).  See module docstring.
-    region_properties : None, "all", or list[str]
+    region_properties : None, "all", "none", or list[str]
         Which regionprop columns to include in the output.
-        ``None`` / ``"all"`` → keep every column found in the existing CSV.
-        A list of names → include only those columns (if present in the CSV).
+
+        ``None`` / ``"all"``
+            Keep every regionprop column found in the existing CSV (default).
+        ``"none"``
+            Strip all regionprop columns; output contains only the base
+            columns (frame counters, track id, label, confidence, pos_x/y,
+            area, bbox).
+        list of strings
+            Include only the named columns that are present in the CSV
+            (e.g. ``["eccentricity", "solidity"]``).  Use
+            :func:`list_region_properties` to see what is available.
     combined : bool
         If True write a single ``all_tracks.csv``; otherwise one file per track.
     overwrite : bool
@@ -587,7 +596,9 @@ def export_tracking(
 
         # Extra regionprop columns
         extra_cols = [c for c in df.columns if c not in _BASE_COLS]
-        if isinstance(region_properties, list):
+        if region_properties == "none":
+            extra_cols = []
+        elif isinstance(region_properties, list):
             extra_cols = [c for c in extra_cols if c in region_properties]
         # region_properties=None or "all" → keep all extra columns
         region_props_d[tid] = {c: df[c].to_numpy() for c in extra_cols}

--- a/octron/tools/export_tracking.py
+++ b/octron/tools/export_tracking.py
@@ -21,22 +21,18 @@ largest   : use the value from the single largest segment per frame.  Fully
             numeric output.  Fast, CSV-only, no zarr required.
 weighted  : area-weighted mean across all segments per frame.  Fully numeric.
             ``area`` becomes the *sum* of segment areas.
-mask_com  : ``pos_x``/``pos_y`` replaced by full centre-of-mass from zarr masks
-            (most robust against flickering outlier segments).  All other
-            columns resolved via weighted.  ``area`` is the sum of segment areas.
-            Requires the zarr archive.
 
-Special cases (largest / weighted / mask_com only)
---------------------------------------------------
+Special cases (largest / weighted only)
+---------------------------------------
 area      : ``largest`` → area of the largest segment.
-            ``weighted`` / ``mask_com`` → sum of all segment areas.
+            ``weighted`` → sum of all segment areas.
 orientation : always resolved via ``largest`` (circular quantity; weighted mean
               is undefined for angles).
 
 Public functions
 ----------------
-export_tracking        : Export CSVs from an existing predictions directory.
-compute_mask_centroids : Compute per-frame centre-of-mass from zarr masks.
+export_tracking            : Export CSVs from an existing predictions directory.
+compute_weighted_centroids : Per-frame area-weighted (cx, cy) read from CSVs.
 """
 
 import ast
@@ -47,123 +43,6 @@ from time import perf_counter
 from typing import Literal
 
 import numpy as np
-
-
-# ---------------------------------------------------------------------------
-# Letterbox helper (shared with render.py)
-# ---------------------------------------------------------------------------
-
-def _letterbox_bounds(mask_h, mask_w, vid_h, vid_w):
-    """
-    Compute the video-content region within a mask stored at inference resolution.
-
-    YOLO (retina_masks=False) letterboxes frames to fit within imgsz and then
-    pads to the nearest multiple of stride (32).  The padding is centred, so the
-    actual video content starts at (pad_y, pad_x) within the stored mask.
-
-    Returns
-    -------
-    content_h, content_w : int
-    pad_y, pad_x : int
-    """
-    content_h = round(vid_h * mask_w / vid_w)
-    if content_h <= mask_h:
-        content_w = mask_w
-        pad_y = (mask_h - content_h) // 2
-        pad_x = 0
-    else:
-        content_h = mask_h
-        content_w = round(vid_w * mask_h / vid_h)
-        pad_y = 0
-        pad_x = (mask_w - content_w) // 2
-    return content_h, content_w, pad_y, pad_x
-
-
-# ---------------------------------------------------------------------------
-# compute_mask_centroids (moved from render.py)
-# ---------------------------------------------------------------------------
-
-def compute_mask_centroids(zarr_root, track_ids, frame_start, frame_end, downsample=4):
-    """
-    Compute per-frame centre-of-mass centroids directly from zarr segmentation
-    masks, as a more stable alternative to the bounding-box-derived positions
-    stored in the tracking CSVs.
-
-    Masks are downsampled before computing CoM for speed, then coordinates are
-    scaled back to full resolution.  Processing is vectorised over the batch
-    dimension — no Python loop over frames.
-
-    Parameters
-    ----------
-    zarr_root : zarr.Group
-        Root zarr group from a predictions.zarr archive.
-    track_ids : iterable
-        Track IDs to process (must match the ``{tid}_masks`` array naming).
-    frame_start : int
-        First frame index to process (inclusive).
-    frame_end : int
-        Last frame index to process (exclusive).
-    downsample : int
-        Spatial downscale factor applied before computing CoM.  ``4`` (default)
-        gives 16× fewer pixels with negligible centroid error at full resolution.
-
-    Returns
-    -------
-    centroids : dict
-        ``{track_id: {frame_idx: (cx, cy)}}`` — float pixel coordinates in the
-        original full-resolution frame.  Only frames with at least one mask
-        pixel are included.
-    """
-    _BATCH = 500
-    track_ids = list(track_ids)
-    centroids = {tid: {} for tid in track_ids}
-    n_frames = frame_end - frame_start
-    n_batches_per_track = max(1, (n_frames + _BATCH - 1) // _BATCH)
-    total_batches = len(track_ids) * n_batches_per_track
-    _bar_width = 30
-    batch_idx = 0
-
-    for tid in track_ids:
-        arr_key = f"{tid}_masks"
-        if arr_key not in zarr_root:
-            batch_idx += n_batches_per_track
-            continue
-        zarr_arr = zarr_root[arr_key]
-        n_mask_frames = zarr_arr.shape[0]
-        _mask_h, _mask_w = zarr_arr.shape[1], zarr_arr.shape[2]
-        _vid_h = zarr_arr.attrs.get('video_height', _mask_h) or _mask_h
-        _vid_w = zarr_arr.attrs.get('video_width',  _mask_w) or _mask_w
-        _c_h, _c_w, _p_y, _p_x = _letterbox_bounds(_mask_h, _mask_w, _vid_h, _vid_w)
-
-        for batch_start in range(frame_start, min(frame_end, n_mask_frames), _BATCH):
-            batch_end = min(batch_start + _BATCH, frame_end, n_mask_frames)
-            raw = np.asarray(zarr_arr[batch_start:batch_end])  # (n, H, W)
-
-            mask = (raw[:, ::downsample, ::downsample] == 1)  # (n, dH, dW) bool
-            dH, dW = mask.shape[1], mask.shape[2]
-
-            count = mask.sum(axis=(1, 2))
-            ys = np.arange(dH, dtype=np.float32)[None, :, None]
-            xs = np.arange(dW, dtype=np.float32)[None, None, :]
-            cy_ds = (mask * ys).sum(axis=(1, 2)) / np.maximum(count, 1)
-            cx_ds = (mask * xs).sum(axis=(1, 2)) / np.maximum(count, 1)
-
-            cx_full = (cx_ds * downsample - _p_x) * _vid_w / _c_w
-            cy_full = (cy_ds * downsample - _p_y) * _vid_h / _c_h
-
-            for i, frame_idx in enumerate(range(batch_start, batch_end)):
-                if count[i] > 0:
-                    centroids[tid][frame_idx] = (float(cx_full[i]), float(cy_full[i]))
-
-            batch_idx += 1
-            pct = batch_idx / total_batches
-            filled = int(_bar_width * pct)
-            bar = "█" * filled + "░" * (_bar_width - filled)
-            print(f"  [{bar}] track {tid} | {batch_start}-{batch_end} | {pct:.0%}",
-                  end="\r")
-
-    print()
-    return centroids
 
 
 # ---------------------------------------------------------------------------
@@ -496,7 +375,7 @@ def _export_tracking_from_data(
     scalars:
 
     - ``area`` uses the *largest segment's area* for ``"largest"``, and the
-      *sum of all segment areas* for ``"weighted"`` and ``"mask_com"``.
+      *sum of all segment areas* for ``"weighted"``.
     - ``orientation`` always uses the largest segment (circular quantity).
 
     Parameters
@@ -521,9 +400,9 @@ def _export_tracking_from_data(
     video_metadata : dict
         Keys: video_name, frame_count, frame_count_analyzed,
               video_height, video_width, created_at.
-    method : {"raw", "largest", "weighted", "mask_com"}
+    method : {"raw", "largest", "weighted"}
     zarr_root : zarr.Group or None
-        Required only when method == "mask_com".
+        Unused (kept for backwards-compatible call signature).
     combined : bool
         True → single all_tracks.csv; False → one file per track.
     fmt : {"csv", "parquet"}
@@ -542,25 +421,10 @@ def _export_tracking_from_data(
             "method='raw' + fmt='parquet': any column containing tuple-strings "
             "will be stored as a string column (including the scalar values in "
             "single-segment rows), losing numeric type on disk. Use a "
-            "resolution method (largest/weighted/mask_com) for fully numeric "
-            "parquet output."
+            "resolution method (largest/weighted) for fully numeric parquet output."
         )
 
-    # Pre-compute mask centroids once across all tracks when needed
-    mask_centroids_lookup = {}
-    if method == "mask_com" and zarr_root is not None:
-        all_frames = [int(f) for tid in track_ids for f in frame_indices.get(tid, [])]
-        if all_frames:
-            print("Computing mask centroids from zarr...")
-            mask_centroids_lookup = compute_mask_centroids(
-                zarr_root, track_ids,
-                frame_start=min(all_frames),
-                frame_end=max(all_frames) + 1,
-            )
-
-    # Determine per-prop resolver based on method.
-    # mask_com falls back to weighted for all non-centroid metrics.
-    _use_weighted = method in ("weighted", "mask_com")
+    _use_weighted = method == "weighted"
 
     from tqdm import tqdm
 
@@ -583,19 +447,13 @@ def _export_tracking_from_data(
             px, py = sx, sy
         elif method == "weighted":
             px, py = _resolve_xy_weighted(sx, sy, sa)
-        elif method == "mask_com" and mask_centroids_lookup.get(tid):
-            fi_arr = np.asarray(frame_indices[tid])
-            lookup = mask_centroids_lookup[tid]
-            px = np.array([lookup.get(int(f), (np.nan, np.nan))[0] for f in fi_arr])
-            py = np.array([lookup.get(int(f), (np.nan, np.nan))[1] for f in fi_arr])
-        else:
-            # "largest" or mask_com fallback when zarr unavailable
+        else:  # "largest"
             px, py = _resolve_xy_largest(sx, sy, sa)
 
         # --- area ---
         # "raw"      → tuple-strings pass through unchanged.
         # "largest"  → area of the largest segment.
-        # "weighted" / "mask_com" → sum of all segment areas (total mask coverage).
+        # "weighted" → sum of all segment areas (total mask coverage).
         if method == "raw":
             area = sa
         elif _use_weighted:
@@ -877,6 +735,54 @@ def _autodetect_video(predictions_path: Path):
     return None
 
 
+def compute_weighted_centroids(predictions_path, track_ids=None):
+    """
+    Compute per-frame area-weighted centroids by re-reading the raw
+    ``pos_x``/``pos_y``/``area`` columns from per-track prediction CSVs.
+
+    Multi-segment frames (where the columns hold tuple-strings) are reduced
+    to a single (cx, cy) via ``Σ(aᵢ·xᵢ) / Σ(aᵢ)``.  Single-segment scalars
+    pass through unchanged.
+
+    Parameters
+    ----------
+    predictions_path : str or Path
+        Path to an ``octron_predictions/<video>/`` output directory.
+    track_ids : iterable[int] or None
+        If given, only compute centroids for these track IDs.
+
+    Returns
+    -------
+    dict[int, dict[int, tuple[float, float]]]
+        ``{track_id: {frame_idx: (cx, cy)}}``.
+    """
+    import pandas as pd
+    from natsort import natsorted
+
+    predictions_path = Path(predictions_path)
+    csvs = natsorted(predictions_path.glob("*track_*.csv"))
+    if not csvs:
+        return {}
+
+    wanted = set(track_ids) if track_ids is not None else None
+    out = {}
+    for csv_file in csvs:
+        df = pd.read_csv(csv_file, skiprows=_CSV_HEADER_LINES)
+        if df.empty:
+            continue
+        tid = int(df["track_id"].iloc[0])
+        if wanted is not None and tid not in wanted:
+            continue
+        sx = df["pos_x"].to_numpy(dtype=object)
+        sy = df["pos_y"].to_numpy(dtype=object)
+        sa = (df["area"].to_numpy(dtype=object)
+              if "area" in df.columns else np.ones(len(df), dtype=object))
+        cx, cy = _resolve_xy_weighted(sx, sy, sa)
+        fi = df["frame_idx"].to_numpy()
+        out[tid] = {int(fi[i]): (float(cx[i]), float(cy[i])) for i in range(len(fi))}
+    return out
+
+
 def list_region_properties(*, print_output: bool = True) -> dict:
     """Return (and optionally print) all available regionprop names grouped by category.
 
@@ -899,7 +805,7 @@ def list_region_properties(*, print_output: bool = True) -> dict:
 def export_tracking(
     predictions_path,
     output_dir=None,
-    method: Literal["raw", "largest", "weighted", "mask_com"] = "raw",
+    method: Literal["raw", "largest", "weighted"] = "raw",
     region_properties=None,
     video_path=None,
     fmt: Literal["csv", "parquet"] = "csv",
@@ -920,7 +826,7 @@ def export_tracking(
         Path to an ``octron_predictions/<video>/`` output directory.
     output_dir : str or Path or None
         Where to write the output CSVs.  Defaults to *predictions_path*.
-    method : {"raw", "largest", "weighted", "mask_com"}
+    method : {"raw", "largest", "weighted"}
         How to handle multi-segment rows (default: ``"raw"`` — pass through
         tuple-strings unchanged).  See module docstring.
     region_properties : None, "all", "none", "shape", "intensity", or list[str]
@@ -984,7 +890,7 @@ def export_tracking(
         raise FileNotFoundError(f"No tracking CSV files found in {predictions_path}")
     logger.info(f"Found {len(csvs)} tracking CSV(s) in {predictions_path.name}")
 
-    # --- Discover zarr (optional; required only for mask_com) ---
+    # --- Discover zarr (optional; needed only when computing region_properties) ---
     t4 = perf_counter()
     zarr_root = None
     zarr_candidate = predictions_path / "predictions.zarr"
@@ -993,12 +899,6 @@ def export_tracking(
         store = zarr.storage.LocalStore(zarr_candidate, read_only=True)
         zarr_root = zarr.open_group(store=store, mode="r")
         logger.info("Found zarr archive")
-    elif method == "mask_com":
-        logger.warning(
-            "method='mask_com' requested but no zarr archive found — "
-            "falling back to 'largest'."
-        )
-        method = "largest"
 
     # --- Resolve region_properties group aliases ---
     _GROUP_ALIASES = {"shape": "Size and Shape", "intensity": "Intensity"}

--- a/octron/tools/export_tracking.py
+++ b/octron/tools/export_tracking.py
@@ -219,6 +219,8 @@ def _zarr_batch_worker(args):
 
     results = {}
     t_binary = t_bbox = t_label = t_props = 0.0
+    n_video_misses = 0
+    needs_intensity = bool(cap is not None and any(p in _INTENSITY_PROPS for p in computable))
     for fi, pos in zip(batch_fi, fi_positions):
         raw = raw_batch[fi - fi_lo]
 
@@ -252,6 +254,14 @@ def _zarr_batch_worker(args):
                 rgb = _cv2.cvtColor(frame, _cv2.COLOR_BGR2RGB)
                 lum = _cv2.cvtColor(frame, _cv2.COLOR_BGR2GRAY)
                 intensity_crop = _np.dstack([rgb, lum])[r0:r1, c0:c1]
+            elif needs_intensity:
+                # Video read failed (EOF past zarr's frame count, transient
+                # network glitch, or corrupted frame).  Skip rather than feed
+                # intensity_image=None into a regionprops_table that requested
+                # intensity_max/_mean/_min/_std/weighted_centroid/weighted_var*
+                # — skimage raises AttributeError on the first such property.
+                n_video_misses += 1
+                continue
 
         labeled = _measure.label(binary[r0:r1, c0:c1], background=0, connectivity=2)
         td = _pc()
@@ -332,7 +342,8 @@ def _zarr_batch_worker(args):
     if cap is not None:
         cap.release()
 
-    return results, fi_lo, fi_hi, t1 - t0, _pc() - t1, t_binary, t_bbox, t_label, t_props
+    return (results, fi_lo, fi_hi, t1 - t0, _pc() - t1,
+            t_binary, t_bbox, t_label, t_props, n_video_misses)
 
 
 # ---------------------------------------------------------------------------
@@ -810,7 +821,7 @@ def compute_region_props_from_zarr(zarr_root, track_ids, frame_indices_dict, pro
         return {}
 
     import os
-    from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor
+    from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor, as_completed
 
     n_workers = min(8, os.cpu_count() or 4)
     # ProcessPoolExecutor bypasses the GIL for true CPU parallelism.
@@ -839,6 +850,31 @@ def compute_region_props_from_zarr(zarr_root, track_ids, frame_indices_dict, pro
         fi_to_pos = {int(fi): i for i, fi in enumerate(frame_idxs)}
         valid_fi = sorted(fi for fi in fi_to_pos if fi < n_zarr_frames)
 
+        # Sanity-check video frame count against zarr frame count.  A
+        # mismatch (typically video has fewer frames) means some frames the
+        # worker tries to read will fail; warn up front rather than after
+        # hours of compute.
+        if video_path is not None:
+            try:
+                import cv2 as _cv2_check
+                _cap_check = _cv2_check.VideoCapture(str(video_path))
+                if _cap_check.isOpened():
+                    n_video_frames = int(_cap_check.get(_cv2_check.CAP_PROP_FRAME_COUNT))
+                    if n_video_frames != n_zarr_frames:
+                        _log.warning(
+                            f"track {tid}: video reports {n_video_frames} frames, "
+                            f"zarr has {n_zarr_frames}. Frames past the smaller of "
+                            f"the two will be skipped (intensity unavailable)."
+                        )
+                    else:
+                        _log.debug(
+                            f"track {tid}: video and zarr both report "
+                            f"{n_video_frames} frames."
+                        )
+                _cap_check.release()
+            except Exception as e:
+                _log.debug(f"Could not pre-check video frame count: {e}")
+
         # per-frame result as list-of-dicts — handles dynamically-expanded
         # column names (e.g. moments_hu → moments_hu-0 … moments_hu-6)
         rows = [{} for _ in range(n)]
@@ -861,20 +897,54 @@ def compute_region_props_from_zarr(zarr_root, track_ids, frame_indices_dict, pro
             for s in range(0, len(valid_fi), _PROPS_BATCH)
         ]
 
+        # as_completed lets one bad batch fail without aborting the rest of
+        # the track — completed batches' rows survive even if a later batch
+        # crashes.  Defence against losing hours of compute to a single bug.
+        n_video_misses_total = 0
+        n_failed_batches = 0
         with ExecutorClass(max_workers=n_workers) as executor:
-            for batch_results, fi_lo, fi_hi, t_io, t_cpu, t_bin, t_bbox, t_lbl, t_rpt in tqdm(
-                executor.map(_zarr_batch_worker, batch_args),
-                total=len(batch_args),
+            future_to_range = {}
+            for args in batch_args:
+                fut = executor.submit(_zarr_batch_worker, args)
+                future_to_range[fut] = (args[2][0], args[2][-1])
+            for fut in tqdm(
+                as_completed(future_to_range),
+                total=len(future_to_range),
                 desc=f"  track {tid}", unit="batch", leave=False,
             ):
+                try:
+                    (batch_results, fi_lo, fi_hi, t_io, t_cpu,
+                     t_bin, t_bbox, t_lbl, t_rpt, n_misses) = fut.result()
+                except Exception as e:
+                    fi_lo, fi_hi = future_to_range[fut]
+                    n_failed_batches += 1
+                    _log.error(
+                        f"track {tid}: batch {fi_lo}-{fi_hi} failed ({type(e).__name__}: {e}); "
+                        f"frames in this batch will be NaN. Continuing with remaining batches."
+                    )
+                    continue
                 _log.debug(
                     f"batch {fi_lo}-{fi_hi}: zarr_read={t_io:.3f}s  "
                     f"regionprops={t_cpu:.3f}s "
                     f"(binary={t_bin:.3f}s  bbox={t_bbox:.3f}s  "
                     f"label={t_lbl:.3f}s  props_table={t_rpt:.3f}s)"
                 )
+                n_video_misses_total += n_misses
                 for pos, frame_result in batch_results.items():
                     rows[pos].update(frame_result)
+
+        if n_video_misses_total:
+            _log.info(
+                f"track {tid}: {n_video_misses_total} frame(s) skipped because the "
+                f"video read failed (likely past video EOF or a transient I/O glitch); "
+                f"those rows are NaN in the output."
+            )
+        if n_failed_batches:
+            _log.warning(
+                f"track {tid}: {n_failed_batches} batch(es) failed entirely; "
+                f"affected frame ranges are NaN in the output. Check the ERROR "
+                f"lines above for batch boundaries."
+            )
 
         # Collect all column names that actually appeared (handles expansion)
         all_keys = set()

--- a/octron/tools/export_tracking.py
+++ b/octron/tools/export_tracking.py
@@ -56,13 +56,102 @@ import numpy as np
 #   intensity_mean_r, intensity_mean_g, intensity_mean_b, intensity_mean_lum
 _INTENSITY_PROPS = frozenset({
     "intensity_max", "intensity_mean", "intensity_min", "intensity_std",
+    "weighted_centroid",
 })
 
-# Rename skimage's numeric channel suffixes to readable labels.
-# Channels are stacked as (R, G, B, luminance) in the worker.
-_CHANNEL_SUFFIX = {"-0": "_r", "-1": "_g", "-2": "_b", "-3": "_lum"}
+# Properties whose values are NOT translation-invariant: they depend on the
+# absolute pixel coordinates, so cropping the input shifts the output by the
+# bbox origin and the result must be offset back into full-frame coordinates.
+# (Plain `bbox` columns are emitted from the bbox-detection step, not from
+# regionprops, so they are not listed here.)
+_TRANSLATION_VARIANT_PROPS = frozenset({
+    "centroid",
+    "weighted_centroid",
+})
+
+# Properties whose multichannel-intensity output gains an extra trailing
+# channel suffix on a 4-channel intensity image (R, G, B, luminance):
+#   intensity_mean-0..3  →  intensity_mean_{r,g,b,lum}
+#   weighted_centroid-{axis}-{channel}  →  weighted_centroid_{y,x}_{r,g,b,lum}
+_MULTICHANNEL_INTENSITY_PROPS = frozenset({
+    "intensity_max", "intensity_mean", "intensity_min", "intensity_std",
+    "weighted_centroid",
+})
+
+# Properties whose first numeric suffix is a spatial axis (y, x).
+_POSITION_PROPS = frozenset({"centroid", "weighted_centroid"})
+
+_AXIS_LABELS = ("y", "x")
+_CHANNEL_LABELS = ("r", "g", "b", "lum")
 
 _PROPS_BATCH = 500  # zarr frames per contiguous read when computing props
+
+
+def _rename_prop_column(col_key, has_intensity):
+    """Rename skimage's numeric '-N' suffixes to readable labels.
+
+    Skimage's regionprops_table flattens multi-dimensional outputs by suffixing
+    each numeric index, with the channel axis appended last when the intensity
+    image is multi-channel.  For our 4-channel (R, G, B, luminance) layout:
+
+      intensity_mean-0           →  intensity_mean_r
+      weighted_centroid-0-0      →  weighted_centroid_y_r
+      weighted_centroid-1-3      →  weighted_centroid_x_lum
+      centroid-0                 →  centroid_y
+      moments_hu-0               →  moments_hu-0           (unchanged)
+
+    The ``has_intensity`` flag tells us whether to interpret the trailing
+    index as a channel — without an intensity image, even multichannel-aware
+    props like ``weighted_centroid`` are not present.
+    """
+    parts = col_key.split("-")
+    if len(parts) == 1:
+        return col_key
+
+    base = parts[0]
+    nums = parts[1:]
+
+    is_pos = base in _POSITION_PROPS
+    is_multich_intensity = has_intensity and base in _MULTICHANNEL_INTENSITY_PROPS
+
+    if is_multich_intensity:
+        try:
+            ch_idx = int(nums[-1])
+        except ValueError:
+            return col_key
+        ch_label = (
+            _CHANNEL_LABELS[ch_idx]
+            if 0 <= ch_idx < len(_CHANNEL_LABELS) else nums[-1]
+        )
+        spatial = nums[:-1]
+        if is_pos and len(spatial) == 1:
+            try:
+                ax_idx = int(spatial[0])
+            except ValueError:
+                return col_key
+            ax_label = (
+                _AXIS_LABELS[ax_idx]
+                if 0 <= ax_idx < len(_AXIS_LABELS) else spatial[0]
+            )
+            return f"{base}_{ax_label}_{ch_label}"
+        if not spatial:
+            return f"{base}_{ch_label}"
+        # Unexpected spatial-suffix shape — keep as-is to avoid silent loss.
+        return col_key
+
+    if is_pos and len(nums) == 1:
+        try:
+            ax_idx = int(nums[0])
+        except ValueError:
+            return col_key
+        ax_label = (
+            _AXIS_LABELS[ax_idx]
+            if 0 <= ax_idx < len(_AXIS_LABELS) else nums[0]
+        )
+        return f"{base}_{ax_label}"
+
+    # Default: keep multi-value expansions like moments_hu-0..6 unchanged.
+    return col_key
 
 
 def _zarr_batch_worker(args):
@@ -142,17 +231,36 @@ def _zarr_batch_worker(args):
         t_label += td - tc
         t_props += te - td
 
+        # Crop-then-compute is correct only for translation-invariant
+        # properties.  For variant ones (centroid, weighted_centroid)
+        # we shift each spatial axis back into full-frame coordinates.
+        # Skimage names the spatial axis as the FIRST numeric suffix:
+        #   centroid-0          → axis 0 (y) → add r0
+        #   centroid-1          → axis 1 (x) → add c0
+        #   weighted_centroid-0-{ch}  → axis 0 (y) → add r0
+        #   weighted_centroid-1-{ch}  → axis 1 (x) → add c0
+        for col_key, vals in props.items():
+            base = col_key.split("-")[0]
+            if base not in _TRANSLATION_VARIANT_PROPS:
+                continue
+            parts = col_key.split("-")
+            if len(parts) < 2:
+                continue
+            try:
+                ax_idx = int(parts[1])
+            except ValueError:
+                continue
+            offset = r0 if ax_idx == 0 else c0 if ax_idx == 1 else 0
+            if offset:
+                props[col_key] = vals + offset
+
         frame_result = {}
-        _ch = {"-0": "_r", "-1": "_g", "-2": "_b", "-3": "_lum"}
+        has_intensity = intensity_crop is not None
         for col_key, vals in props.items():
             base = col_key.split("-")[0]
             if base not in computable and col_key not in computable:
                 continue
-            out_key = col_key
-            for old_suf, new_suf in _ch.items():
-                if col_key.endswith(old_suf):
-                    out_key = col_key[: -len(old_suf)] + new_suf
-                    break
+            out_key = _rename_prop_column(col_key, has_intensity)
             frame_result[out_key] = (
                 float(vals[0]) if len(vals) == 1
                 else str(tuple(float(v) for v in vals))
@@ -303,9 +411,10 @@ def _ordered_columns(df_columns):
     """Return df_columns in canonical order.
 
     Order: base cols → shape props → intensity props (ALL_REGION_PROPERTIES
-    order).  Multi-value expansions (moments_hu-0 … -6) and channel
-    expansions (intensity_mean_r/g/b/lum) are grouped immediately after
-    their base name.  Unknown columns follow at the end.
+    order).  Multi-value expansions (moments_hu-0 … -6), channel expansions
+    (intensity_mean_r/g/b/lum), axis expansions (centroid_y/x), and
+    axis-channel expansions (weighted_centroid_y_r … _x_lum) are all grouped
+    immediately after their base name.  Unknown columns follow at the end.
     """
     from octron.yolo_octron.constants import ALL_REGION_PROPERTIES
 
@@ -329,6 +438,10 @@ def _ordered_columns(df_columns):
             _add(c)
         for suf in _CHANNEL_SUFFIXES:
             _add(prop + suf)
+        for ax in _AXIS_LABELS:
+            _add(f"{prop}_{ax}")
+            for suf in _CHANNEL_SUFFIXES:
+                _add(f"{prop}_{ax}{suf}")
 
     for col in _COL_BASE:
         _add(col)

--- a/octron/tools/export_tracking.py
+++ b/octron/tools/export_tracking.py
@@ -2,27 +2,32 @@
 OCTRON tracking export pipeline.
 
 Converts zarr mask archives and per-track CSVs produced by ``octron predict``
-into clean, analysis-ready CSV files with resolved scalar columns.
+into analysis-ready CSV (or parquet) files.
 
-All columns that contain tuple-strings (produced when multiple disconnected
-segments are detected in a single frame) are resolved to scalars using the
-chosen ``method``.  The same strategy applies to every column —
-positions, areas, shape descriptors, and intensity properties — so the output
-is always fully numeric.
+When multiple disconnected segments are detected in a single frame, every
+per-segment column (positions, areas, shape descriptors, intensity properties)
+is stored as a tuple-string — e.g. ``"(120.5, 85.3)"``.  The ``method``
+parameter controls how those tuple-valued rows are handled at export time.
 
-Centroid / resolution methods
-------------------------------
-largest   : use the value from the single largest segment per frame (default).
-            Fast, CSV-only, no zarr required.
-weighted  : area-weighted mean across all segments per frame.
-            CSV-only.  ``area`` becomes the *sum* of segment areas.
+Resolution methods
+------------------
+raw       : default.  Tuple-strings pass through unchanged; single-segment
+            rows stay scalar.  Matches the original predict output (no info
+            loss).  CSV columns end up as ``object`` dtype on read.  When
+            writing parquet, mixed columns are stored as strings — including
+            the scalar values — which loses numeric typing on disk; a warning
+            is emitted in that case.
+largest   : use the value from the single largest segment per frame.  Fully
+            numeric output.  Fast, CSV-only, no zarr required.
+weighted  : area-weighted mean across all segments per frame.  Fully numeric.
+            ``area`` becomes the *sum* of segment areas.
 mask_com  : ``pos_x``/``pos_y`` replaced by full centre-of-mass from zarr masks
             (most robust against flickering outlier segments).  All other
             columns resolved via weighted.  ``area`` is the sum of segment areas.
             Requires the zarr archive.
 
-Special cases
--------------
+Special cases (largest / weighted / mask_com only)
+--------------------------------------------------
 area      : ``largest`` → area of the largest segment.
             ``weighted`` / ``mask_com`` → sum of all segment areas.
 orientation : always resolved via ``largest`` (circular quantity; weighted mean
@@ -475,7 +480,7 @@ def _export_tracking_from_data(
     bbox,
     region_props,
     video_metadata,
-    method="largest",
+    method="raw",
     zarr_root=None,
     combined=False,
     fmt="csv",
@@ -486,10 +491,9 @@ def _export_tracking_from_data(
     This is the single place where prediction CSVs are written — called by
     both ``predict_batch`` (in-memory path) and ``export_tracking`` (disk path).
 
-    All tuple-valued columns (produced when multiple disconnected segments are
-    detected in a frame) are resolved to scalars using ``method``.
-    The same strategy applies to positions, areas, and all regionprops columns,
-    with two exceptions:
+    Method ``"raw"`` (default) preserves multi-segment values as tuple-strings,
+    matching the original predict output.  The other methods resolve tuples to
+    scalars:
 
     - ``area`` uses the *largest segment's area* for ``"largest"``, and the
       *sum of all segment areas* for ``"weighted"`` and ``"mask_com"``.
@@ -517,19 +521,30 @@ def _export_tracking_from_data(
     video_metadata : dict
         Keys: video_name, frame_count, frame_count_analyzed,
               video_height, video_width, created_at.
-    method : {"largest", "weighted", "mask_com"}
+    method : {"raw", "largest", "weighted", "mask_com"}
     zarr_root : zarr.Group or None
         Required only when method == "mask_com".
     combined : bool
         True → single all_tracks.csv; False → one file per track.
     fmt : {"csv", "parquet"}
         Output format.  Parquet stores video metadata in the file schema.
+        ``method="raw"`` + ``fmt="parquet"`` produces string-typed columns
+        for any field that contains tuple-strings; a warning is emitted.
     """
     import pandas as pd
     from loguru import logger
 
     output_dir = Path(output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
+
+    if method == "raw" and fmt == "parquet":
+        logger.warning(
+            "method='raw' + fmt='parquet': any column containing tuple-strings "
+            "will be stored as a string column (including the scalar values in "
+            "single-segment rows), losing numeric type on disk. Use a "
+            "resolution method (largest/weighted/mask_com) for fully numeric "
+            "parquet output."
+        )
 
     # Pre-compute mask centroids once across all tracks when needed
     mask_centroids_lookup = {}
@@ -564,7 +579,9 @@ def _export_tracking_from_data(
         sa = np.asarray(segments_area.get(tid, np.ones(n)), dtype=object)
 
         # --- pos_x / pos_y ---
-        if method == "weighted":
+        if method == "raw":
+            px, py = sx, sy
+        elif method == "weighted":
             px, py = _resolve_xy_weighted(sx, sy, sa)
         elif method == "mask_com" and mask_centroids_lookup.get(tid):
             fi_arr = np.asarray(frame_indices[tid])
@@ -576,9 +593,12 @@ def _export_tracking_from_data(
             px, py = _resolve_xy_largest(sx, sy, sa)
 
         # --- area ---
-        # "largest" → area of the largest segment.
+        # "raw"      → tuple-strings pass through unchanged.
+        # "largest"  → area of the largest segment.
         # "weighted" / "mask_com" → sum of all segment areas (total mask coverage).
-        if _use_weighted:
+        if method == "raw":
+            area = sa
+        elif _use_weighted:
             area = _sum_segments_area(sa)
         else:
             area = _resolve_prop_largest(sa, sa)
@@ -590,8 +610,10 @@ def _export_tracking_from_data(
             prop_items, desc=f"  resolving props", unit="prop", leave=False,
         ):
             pv = np.asarray(prop_values, dtype=object)
-            # orientation is a circular quantity — always use largest segment.
-            if prop_name == "orientation" or not _use_weighted:
+            if method == "raw":
+                resolved_props[prop_name] = pv
+            elif prop_name == "orientation" or not _use_weighted:
+                # orientation is a circular quantity — always use largest segment.
                 resolved_props[prop_name] = _resolve_prop_largest(pv, sa)
             else:
                 resolved_props[prop_name] = _resolve_prop_weighted(pv, sa)
@@ -877,7 +899,7 @@ def list_region_properties(*, print_output: bool = True) -> dict:
 def export_tracking(
     predictions_path,
     output_dir=None,
-    method: Literal["largest", "weighted", "mask_com"] = "largest",
+    method: Literal["raw", "largest", "weighted", "mask_com"] = "raw",
     region_properties=None,
     video_path=None,
     fmt: Literal["csv", "parquet"] = "csv",
@@ -888,8 +910,9 @@ def export_tracking(
     Export tracking CSVs from an existing OCTRON predictions directory.
 
     Reads the per-track CSVs and (optionally) zarr masks produced by
-    ``octron predict``, resolves all tuple-valued columns to scalars using
-    the chosen strategy, and writes new CSVs.
+    ``octron predict`` and writes new CSVs.  By default (``method="raw"``)
+    multi-segment values pass through as tuple-strings; the other methods
+    resolve those to scalars.
 
     Parameters
     ----------
@@ -897,9 +920,9 @@ def export_tracking(
         Path to an ``octron_predictions/<video>/`` output directory.
     output_dir : str or Path or None
         Where to write the output CSVs.  Defaults to *predictions_path*.
-    method : {"largest", "weighted", "mask_com"}
-        How to resolve multi-segment rows.  Applied consistently to all
-        columns (positions, areas, regionprops).  See module docstring.
+    method : {"raw", "largest", "weighted", "mask_com"}
+        How to handle multi-segment rows (default: ``"raw"`` — pass through
+        tuple-strings unchanged).  See module docstring.
     region_properties : None, "all", "none", "shape", "intensity", or list[str]
         Which regionprop columns to include in the output.
 

--- a/octron/tools/export_tracking.py
+++ b/octron/tools/export_tracking.py
@@ -57,7 +57,30 @@ import numpy as np
 _INTENSITY_PROPS = frozenset({
     "intensity_max", "intensity_mean", "intensity_min", "intensity_std",
     "weighted_centroid",
+    # Intensity-weighted spatial spread of the per-channel pixel intensities
+    # (variance and covariance about the weighted centroid, per channel).
+    "weighted_var_y", "weighted_var_x", "weighted_cov_yx",
 })
+
+# Pseudo-properties derived from skimage's weighted_moments_central (μ_pq):
+#   weighted_var_y    = μ_20 / μ_00   (intensity-weighted variance along y)
+#   weighted_var_x    = μ_02 / μ_00   (intensity-weighted variance along x)
+#   weighted_cov_yx   = μ_11 / μ_00   (intensity-weighted yx covariance)
+# Each is emitted per channel: e.g. weighted_var_y_r … _lum.
+# These are the "spread" companions to weighted_centroid: small variance →
+# pixels of that colour cluster tightly around the weighted centroid; large
+# variance → they are spread out.  All three are translation-invariant, so
+# they need no bbox-offset correction.
+_WEIGHTED_SPREAD_PROPS = frozenset({
+    "weighted_var_y", "weighted_var_x", "weighted_cov_yx",
+})
+
+# (i, j) suffix on weighted_moments_central → derived spread base name.
+_SPREAD_FROM_MOMENT = {
+    ("2", "0"): "weighted_var_y",
+    ("0", "2"): "weighted_var_x",
+    ("1", "1"): "weighted_cov_yx",
+}
 
 # Properties whose values are NOT translation-invariant: they depend on the
 # absolute pixel coordinates, so cropping the input shifts the output by the
@@ -73,9 +96,11 @@ _TRANSLATION_VARIANT_PROPS = frozenset({
 # channel suffix on a 4-channel intensity image (R, G, B, luminance):
 #   intensity_mean-0..3  →  intensity_mean_{r,g,b,lum}
 #   weighted_centroid-{axis}-{channel}  →  weighted_centroid_{y,x}_{r,g,b,lum}
+#   weighted_var_y-{channel}  →  weighted_var_y_{r,g,b,lum}
 _MULTICHANNEL_INTENSITY_PROPS = frozenset({
     "intensity_max", "intensity_mean", "intensity_min", "intensity_std",
     "weighted_centroid",
+    "weighted_var_y", "weighted_var_x", "weighted_cov_yx",
 })
 
 # Properties whose first numeric suffix is a spatial axis (y, x).
@@ -168,6 +193,15 @@ def _zarr_batch_worker(args):
     from time import perf_counter as _pc
     from pathlib import Path as _Path
 
+    # Translate pseudo-properties to the underlying skimage names.  We expose
+    # weighted_var_y/x and weighted_cov_yx as user-friendly columns derived
+    # from weighted_moments_central; skimage doesn't know those names, so we
+    # ask for the moments and post-process below.
+    wanted_spread = [p for p in computable if p in _WEIGHTED_SPREAD_PROPS]
+    sk_properties = [p for p in computable if p not in _WEIGHTED_SPREAD_PROPS]
+    if wanted_spread and "weighted_moments_central" not in sk_properties:
+        sk_properties.append("weighted_moments_central")
+
     store = _zarr.storage.LocalStore(_Path(zarr_store_path), read_only=True)
     root = _zarr.open_group(store=store, mode="r")
     zarr_arr = root[arr_key]
@@ -222,7 +256,7 @@ def _zarr_batch_worker(args):
         labeled = _measure.label(binary[r0:r1, c0:c1], background=0, connectivity=2)
         td = _pc()
         props = _measure.regionprops_table(
-            labeled, intensity_image=intensity_crop, properties=computable
+            labeled, intensity_image=intensity_crop, properties=sk_properties
         )
         te = _pc()
 
@@ -230,6 +264,28 @@ def _zarr_batch_worker(args):
         t_bbox += tc - tb
         t_label += td - tc
         t_props += te - td
+
+        # Derive intensity-weighted spread columns from weighted_moments_central:
+        #   weighted_var_y_{ch}  = μ_20 / μ_00   (variance along y, per channel)
+        #   weighted_var_x_{ch}  = μ_02 / μ_00
+        #   weighted_cov_yx_{ch} = μ_11 / μ_00
+        # Stored under pseudo-prop names with a single channel suffix so the
+        # downstream rename helper produces e.g. weighted_var_y_r.
+        if wanted_spread and intensity_crop is not None:
+            n_channels = intensity_crop.shape[2] if intensity_crop.ndim == 3 else 1
+            for ch in range(n_channels):
+                m00 = props.get(f"weighted_moments_central-0-0-{ch}")
+                if m00 is None:
+                    continue
+                for (i, j), base in _SPREAD_FROM_MOMENT.items():
+                    if base not in wanted_spread:
+                        continue
+                    m_ij = props.get(f"weighted_moments_central-{i}-{j}-{ch}")
+                    if m_ij is None:
+                        continue
+                    with _np.errstate(divide="ignore", invalid="ignore"):
+                        derived = _np.where(m00 != 0, m_ij / m00, _np.nan)
+                    props[f"{base}-{ch}"] = derived
 
         # Crop-then-compute is correct only for translation-invariant
         # properties.  For variant ones (centroid, weighted_centroid)

--- a/octron/tools/export_tracking.py
+++ b/octron/tools/export_tracking.py
@@ -255,9 +255,14 @@ def _zarr_batch_worker(args):
 
         labeled = _measure.label(binary[r0:r1, c0:c1], background=0, connectivity=2)
         td = _pc()
-        props = _measure.regionprops_table(
-            labeled, intensity_image=intensity_crop, properties=sk_properties
-        )
+        # Suppress numpy's 0/0 RuntimeWarning from weighted_centroid (M/M0
+        # divide).  Regions with zero total intensity in a channel are
+        # legitimate in biological videos — we report them once per track
+        # in compute_region_props_from_zarr instead of as a noisy warning.
+        with _np.errstate(divide="ignore", invalid="ignore"):
+            props = _measure.regionprops_table(
+                labeled, intensity_image=intensity_crop, properties=sk_properties
+            )
         te = _pc()
 
         t_binary += tb - ta
@@ -875,6 +880,43 @@ def compute_region_props_from_zarr(zarr_root, track_ids, frame_indices_dict, pro
         all_keys = set()
         for row in rows:
             all_keys.update(row.keys())
+
+        # Detect region-frames where a channel had zero total intensity.
+        # weighted_* columns come back NaN for those — common in biological
+        # videos when one or more channels are dim or absent.  We surface
+        # this as one INFO line per track instead of skimage's per-call
+        # divide-by-zero RuntimeWarning.  Distinguish from "frame had no
+        # mask" NaN by requiring the column to be PRESENT in the row dict
+        # (rows[i] only has keys for frames where regionprops actually ran).
+        zero_intensity_counts = {}
+        for ch in _CHANNEL_LABELS:
+            suf = f"_{ch}"
+            ch_cols = [c for c in all_keys
+                       if c.startswith("weighted_") and c.endswith(suf)]
+            if not ch_cols:
+                continue
+            probe = ch_cols[0]  # all weighted_*_<ch> share NaN per (frame, ch)
+            n_bad = 0
+            for row in rows:
+                if probe not in row:
+                    continue
+                v = row[probe]
+                if isinstance(v, float) and v != v:
+                    n_bad += 1
+                elif isinstance(v, str) and "nan" in v.lower():
+                    n_bad += 1
+            if n_bad:
+                zero_intensity_counts[ch] = n_bad
+
+        if zero_intensity_counts:
+            summary = ", ".join(
+                f"{ch}={n}" for ch, n in zero_intensity_counts.items()
+            )
+            _log.info(
+                f"track {tid}: zero total intensity in some region-frames "
+                f"({summary}) — weighted_* columns are NaN for those entries. "
+                f"This is normal when a channel is dim or absent in the video."
+            )
 
         tid_result = {}
         for col_key in all_keys:

--- a/octron/tools/render.py
+++ b/octron/tools/render.py
@@ -112,128 +112,14 @@ def _start_mask_prefetch(zarr_root, track_ids, frame_start, frame_end, batch_siz
     return q
 
 
-def _letterbox_bounds(mask_h, mask_w, vid_h, vid_w):
-    """
-    Compute the video-content region within a mask stored at inference resolution.
-
-    YOLO (retina_masks=False) letterboxes frames to fit within imgsz and then
-    pads to the nearest multiple of stride (32).  The padding is centred, so the
-    actual video content starts at (pad_y, pad_x) within the stored mask.
-
-    Returns
-    -------
-    content_h, content_w : int
-        Height and width of the video content area within the mask.
-    pad_y, pad_x : int
-        Top and left padding in mask pixels.
-    """
-    content_h = round(vid_h * mask_w / vid_w)
-    if content_h <= mask_h:
-        # Width is the constraining dimension; y-axis may have padding
-        content_w = mask_w
-        pad_y = (mask_h - content_h) // 2
-        pad_x = 0
-    else:
-        # Height is the constraining dimension; x-axis may have padding
-        content_h = mask_h
-        content_w = round(vid_w * mask_h / vid_h)
-        pad_y = 0
-        pad_x = (mask_w - content_w) // 2
-    return content_h, content_w, pad_y, pad_x
+# _letterbox_bounds and compute_mask_centroids live in export_tracking so they
+# can be used by both the render pipeline and the CSV export pipeline.
+from octron.tools.export_tracking import _letterbox_bounds, compute_mask_centroids  # noqa: F401
 
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
-
-def compute_mask_centroids(zarr_root, track_ids, frame_start, frame_end, downsample=4):
-    """
-    Compute per-frame centre-of-mass centroids directly from zarr segmentation
-    masks, as a more stable alternative to the bounding-box-derived positions
-    stored in the tracking CSVs.
-
-    Masks are downsampled before computing CoM for speed, then coordinates are
-    scaled back to full resolution.  Processing is vectorised over the batch
-    dimension — no Python loop over frames.
-
-    Parameters
-    ----------
-    zarr_root : zarr.Group
-        Root zarr group from a YOLO_results object.
-    track_ids : iterable
-        Track IDs to process (must match the ``{tid}_masks`` array naming).
-    frame_start : int
-        First frame index to process (inclusive).
-    frame_end : int
-        Last frame index to process (exclusive).
-    downsample : int
-        Spatial downscale factor applied before computing CoM.  ``4`` (default)
-        gives 16× fewer pixels with negligible centroid error at full resolution.
-
-    Returns
-    -------
-    centroids : dict
-        ``{track_id: {frame_idx: (cx, cy)}}`` — float pixel coordinates in the
-        original full-resolution frame.  Only frames where at least one mask
-        pixel is present are included.
-    """
-    import numpy as np
-
-    _BATCH = 500
-    track_ids = list(track_ids)
-    centroids = {tid: {} for tid in track_ids}
-    n_frames = frame_end - frame_start
-    n_batches_per_track = max(1, (n_frames + _BATCH - 1) // _BATCH)
-    total_batches = len(track_ids) * n_batches_per_track
-    _bar_width = 30
-    batch_idx = 0
-
-    for tid in track_ids:
-        arr_key = f"{tid}_masks"
-        if arr_key not in zarr_root:
-            batch_idx += n_batches_per_track
-            continue
-        zarr_arr = zarr_root[arr_key]
-        n_mask_frames = zarr_arr.shape[0]
-        # Masks may be stored at inference resolution; read stored video dims so
-        # centroids are returned in video-pixel coordinates, not mask-pixel coords.
-        _mask_h, _mask_w = zarr_arr.shape[1], zarr_arr.shape[2]
-        _vid_h = zarr_arr.attrs.get('video_height', _mask_h) or _mask_h
-        _vid_w = zarr_arr.attrs.get('video_width',  _mask_w) or _mask_w
-        # Account for letterbox padding: the mask includes stride-alignment padding
-        # that does not correspond to video content; subtract it before scaling.
-        _c_h, _c_w, _p_y, _p_x = _letterbox_bounds(_mask_h, _mask_w, _vid_h, _vid_w)
-
-        for batch_start in range(frame_start, min(frame_end, n_mask_frames), _BATCH):
-            batch_end = min(batch_start + _BATCH, frame_end, n_mask_frames)
-            raw = np.asarray(zarr_arr[batch_start:batch_end])  # (n, H, W)
-
-            mask = (raw[:, ::downsample, ::downsample] == 1)  # (n, dH, dW) bool
-            dH, dW = mask.shape[1], mask.shape[2]
-
-            count = mask.sum(axis=(1, 2))
-            ys = np.arange(dH, dtype=np.float32)[None, :, None]
-            xs = np.arange(dW, dtype=np.float32)[None, None, :]
-            cy_ds = (mask * ys).sum(axis=(1, 2)) / np.maximum(count, 1)
-            cx_ds = (mask * xs).sum(axis=(1, 2)) / np.maximum(count, 1)
-
-            # Convert from downsampled-mask coords → full-mask coords → content coords → video coords
-            cx_full = (cx_ds * downsample - _p_x) * _vid_w / _c_w
-            cy_full = (cy_ds * downsample - _p_y) * _vid_h / _c_h
-
-            for i, frame_idx in enumerate(range(batch_start, batch_end)):
-                if count[i] > 0:
-                    centroids[tid][frame_idx] = (float(cx_full[i]), float(cy_full[i]))
-
-            batch_idx += 1
-            pct = batch_idx / total_batches
-            filled = int(_bar_width * pct)
-            bar = "█" * filled + "░" * (_bar_width - filled)
-            print(f"  [{bar}] track {tid} | {batch_start}-{batch_end} | {pct:.0%}",
-                  end="\r")
-
-    print()
-    return centroids
 
 
 def butterworth_smooth_tracklet_positions(pos_lookup, fps, cutoff_hz=2.0, order=4):

--- a/octron/tools/render.py
+++ b/octron/tools/render.py
@@ -112,9 +112,7 @@ def _start_mask_prefetch(zarr_root, track_ids, frame_start, frame_end, batch_siz
     return q
 
 
-# _letterbox_bounds and compute_mask_centroids live in export_tracking so they
-# can be used by both the render pipeline and the CSV export pipeline.
-from octron.tools.export_tracking import _letterbox_bounds, compute_mask_centroids  # noqa: F401
+from octron.tools.export_tracking import compute_weighted_centroids
 
 
 # ---------------------------------------------------------------------------
@@ -317,7 +315,6 @@ def run_tracklets(
     preset="draft",
     also_overlay=False,
     size=None,
-    mask_centroids=False,
     smooth_cutoff_hz=2.0,
     smooth_order=4,
     alpha=0.4,
@@ -358,9 +355,6 @@ def run_tracklets(
         inspecting centroid placement).  Default False.
     size : int
         Side length in pixels of each square tracklet crop.  Default 160.
-    mask_centroids : bool
-        If True, replace bbox-derived centroid positions with the centre-of-mass
-        computed from the segmentation masks.  Default False.
     smooth_cutoff_hz : float
         Butterworth low-pass cutoff (Hz) applied to the centroid trajectories.
         Set to 0 to disable.  Default 2.0 Hz.
@@ -487,21 +481,22 @@ def run_tracklets(
                     f"Consider --tracklet-size {max(max_w, max_h) + 20}."
                 )
 
-    if mask_centroids and results.has_masks:
-        logger.info("Computing mask centre-of-mass centroids...")
-        mask_cent = compute_mask_centroids(
-            results.zarr_root, render_tids, frame_start, frame_end,
-        )
-        replaced = 0
-        for tid, frame_centroids in mask_cent.items():
-            for frame_idx, (cx, cy) in frame_centroids.items():
-                if frame_idx in pos_lookup.get(tid, {}):
-                    row = pos_lookup[tid][frame_idx].copy()
-                    row["pos_x"] = cx
-                    row["pos_y"] = cy
-                    pos_lookup[tid][frame_idx] = row
-                    replaced += 1
-        logger.info(f"Replaced {replaced} centroid(s) with mask CoM")
+    # Override pos_x/pos_y with area-weighted centroids read directly from the
+    # raw CSV tuple-strings.  get_tracking_data() arithmetic-means tuple-valued
+    # rows, which under-weights large segments.  Re-reading and applying the
+    # weighted resolver here gives the correct multi-segment position without
+    # touching the shared yolo_results.py path.
+    weighted_cent = compute_weighted_centroids(predictions_path, render_tids)
+    replaced = 0
+    for tid, frame_centroids in weighted_cent.items():
+        for frame_idx, (cx, cy) in frame_centroids.items():
+            if frame_idx in pos_lookup.get(tid, {}):
+                row = pos_lookup[tid][frame_idx].copy()
+                row["pos_x"] = cx
+                row["pos_y"] = cy
+                pos_lookup[tid][frame_idx] = row
+                replaced += 1
+    logger.debug(f"Applied weighted centroids to {replaced} frame(s)")
 
     if smooth_cutoff_hz and smooth_cutoff_hz > 0:
         butterworth_smooth_tracklet_positions(
@@ -761,7 +756,6 @@ def run_render(
     tracklets=False,
     also_overlay=False,
     tracklet_size=None,
-    tracklet_mask_centroids=False,
     tracklet_smooth_cutoff_hz=2.0,
     tracklet_smooth_order=4,
     tracklet_min_frames=0,
@@ -802,8 +796,6 @@ def run_render(
         When ``tracklets=True``, render the overlay onto the tracklet crops.
     tracklet_size : int
         Side length in pixels of each tracklet crop.  Default 160.
-    tracklet_mask_centroids : bool
-        Use mask CoM instead of bbox centre for tracklet positioning.
     tracklet_smooth_cutoff_hz : float
         Butterworth cutoff (Hz) for centroid smoothing.  0 = off.  Default 2.0.
     tracklet_smooth_order : int
@@ -830,7 +822,6 @@ def run_render(
             preset=preset,
             also_overlay=also_overlay,
             size=tracklet_size,
-            mask_centroids=tracklet_mask_centroids,
             smooth_cutoff_hz=tracklet_smooth_cutoff_hz,
             smooth_order=tracklet_smooth_order,
             alpha=alpha,

--- a/octron/yolo_octron/constants.py
+++ b/octron/yolo_octron/constants.py
@@ -29,10 +29,11 @@ ALL_REGION_PROPERTIES = {
         'solidity',
     ),
     'Intensity': (
-        'intensity_max', 
+        'intensity_max',
         'intensity_mean',
         'intensity_min',
         'intensity_std',
+        'weighted_centroid',
     ),
 }
 

--- a/octron/yolo_octron/constants.py
+++ b/octron/yolo_octron/constants.py
@@ -34,6 +34,9 @@ ALL_REGION_PROPERTIES = {
         'intensity_min',
         'intensity_std',
         'weighted_centroid',
+        'weighted_var_y',
+        'weighted_var_x',
+        'weighted_cov_yx',
     ),
 }
 

--- a/octron/yolo_octron/yolo_octron.py
+++ b/octron/yolo_octron/yolo_octron.py
@@ -2441,7 +2441,7 @@ class YOLO_octron:
                 bbox=_export_bbox,
                 region_props=_export_region_props,
                 video_metadata=_export_video_meta,
-                centroid_method="largest",
+                method="largest",
                 zarr_root=None,
                 combined=False,
             )

--- a/octron/yolo_octron/yolo_octron.py
+++ b/octron/yolo_octron/yolo_octron.py
@@ -2382,33 +2382,69 @@ class YOLO_octron:
                 for track_id in all_ids:
                     _flush_mask_buffer(track_id)
                 
-            # Save each tracking DataFrame with a label column added
+            # Export tracking CSVs via the shared export pipeline
+            _export_labels        = {}
+            _export_frame_ctr     = {}
+            _export_frame_idx     = {}
+            _export_confidence    = {}
+            _export_segments_x    = {}
+            _export_segments_y    = {}
+            _export_segments_area = {}
+            _export_bbox          = {}
+            _export_region_props  = {}
+            _export_video_meta    = {}
+            _BBOX_COLS = {'bbox_x_min', 'bbox_x_max', 'bbox_y_min', 'bbox_y_max',
+                          'bbox_area', 'bbox_aspect_ratio'}
+            _BASE_COLS = {'confidence', 'pos_x', 'pos_y', 'area'} | _BBOX_COLS
+
             for track_id, tr_df in tracking_df_dict.items():
-                label = tr_df.attrs["label"]
-                df_to_save = tr_df.copy()
-                # Add the label column (will be filled with the same value for all rows)
-                df_to_save.insert(0, 'label', label)
-                
-                # Save to CSV with metadata header
-                filename = f'{label}_track_{track_id}.csv'
-                csv_path = save_dir / filename
-                
-                # Create header with metadata
-                header = [
-                    f"video_name: {tr_df.attrs.get('video_name', 'unknown')}",
-                    f"frame_count: {tr_df.attrs.get('frame_count', '')}",
-                    f"frame_count_analyzed: {tr_df.attrs.get('frame_count_analyzed', '')}",
-                    f"video_height: {tr_df.attrs.get('video_height', '')}",
-                    f"video_width: {tr_df.attrs.get('video_width', '')}",
-                    f"created_at: {tr_df.attrs.get('created_at', str(datetime.now()))}",
-                    "", #Empty line for separation
-                ]
-                
-                # Write the header and then the data
-                with open(csv_path, 'w') as f:
-                    f.write('\n'.join(header) + '\n') 
-                    df_to_save.to_csv(f, na_rep='NaN', lineterminator='\n')
-                logger.debug(f"Saved tracking data for '{label}' (track ID: {track_id}) to {filename}")
+                if tr_df.empty:
+                    continue
+                _export_labels[track_id] = tr_df.attrs["label"]
+                _idx = tr_df.index
+                _export_frame_ctr[track_id]     = _idx.get_level_values('frame_counter').to_numpy()
+                _export_frame_idx[track_id]     = _idx.get_level_values('frame_idx').to_numpy()
+                _export_confidence[track_id]    = tr_df['confidence'].to_numpy()
+                _export_segments_x[track_id]    = tr_df['pos_x'].to_numpy()
+                _export_segments_y[track_id]    = tr_df['pos_y'].to_numpy()
+                _export_segments_area[track_id] = (
+                    tr_df['area'].to_numpy() if 'area' in tr_df.columns
+                    else np.ones(len(tr_df))
+                )
+                _export_bbox[track_id] = {
+                    c: tr_df[c].to_numpy() for c in _BBOX_COLS if c in tr_df.columns
+                }
+                _export_region_props[track_id] = {
+                    c: tr_df[c].to_numpy() for c in tr_df.columns if c not in _BASE_COLS
+                }
+                if not _export_video_meta:
+                    _export_video_meta = {
+                        'video_name':           tr_df.attrs.get('video_name', 'unknown'),
+                        'frame_count':          tr_df.attrs.get('frame_count', ''),
+                        'frame_count_analyzed': tr_df.attrs.get('frame_count_analyzed', ''),
+                        'video_height':         tr_df.attrs.get('video_height', ''),
+                        'video_width':          tr_df.attrs.get('video_width', ''),
+                        'created_at':           tr_df.attrs.get('created_at', str(datetime.now())),
+                    }
+
+            from octron.tools.export_tracking import _export_tracking_from_data
+            _export_tracking_from_data(
+                output_dir=save_dir,
+                track_ids=list(tracking_df_dict.keys()),
+                labels=_export_labels,
+                frame_counters=_export_frame_ctr,
+                frame_indices=_export_frame_idx,
+                confidence=_export_confidence,
+                segments_x=_export_segments_x,
+                segments_y=_export_segments_y,
+                segments_area=_export_segments_area,
+                bbox=_export_bbox,
+                region_props=_export_region_props,
+                video_metadata=_export_video_meta,
+                centroid_method="largest",
+                zarr_root=None,
+                combined=False,
+            )
             
             # Save a json file with all metadata / parameters used for prediction 
             json_meta_path = save_dir / 'prediction_metadata.json'

--- a/octron/yolo_octron/yolo_octron.py
+++ b/octron/yolo_octron/yolo_octron.py
@@ -2441,7 +2441,7 @@ class YOLO_octron:
                 bbox=_export_bbox,
                 region_props=_export_region_props,
                 video_metadata=_export_video_meta,
-                method="largest",
+                method="raw",
                 zarr_root=None,
                 combined=False,
             )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ dependencies = [
     "natsort>=8.4.0",
     "loguru>=0.7",
     "typer>=0.12.0",
+    "pyarrow>=15.0.0",
     "huggingface_hub>=1.5.0",
     "transformers>=5.2.0",
     "napari-pyav @ https://github.com/horsto/napari-pyav/releases/download/v0.0.10.2/napari_pyav-0.0.10-py3-none-any.whl",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -152,7 +152,6 @@ def test_render_help():
     assert '--no-labels' in result.output
     assert '--tracklets' in result.output
     assert '--tracklet-size' in result.output
-    assert '--tracklet-mask-centroids' in result.output
     assert '--tracklet-smooth-cutoff' in result.output
     assert '--tracklet-smooth-order' in result.output
     assert '--tracklet-interpolate' in result.output

--- a/tests/test_export_tracking.py
+++ b/tests/test_export_tracking.py
@@ -1,0 +1,533 @@
+"""
+Tests for octron/tools/export_tracking.py.
+
+No video files, zarr archives, or GPU are required — all tests use synthetic
+in-memory data or temporary CSV files.
+
+Column contract
+---------------
+All tuple-valued columns are resolved to scalars in the output.  Original
+column names (pos_x, pos_y, area, …) are kept — no renaming.
+
+  pos_x / pos_y : scalar centroid per chosen method
+  area          : largest segment's area ("largest") OR sum of all segments
+                  ("weighted" / "mask_com")
+  orientation   : always from the largest segment (circular quantity)
+  all other regionprops : resolved by chosen method
+
+Covered
+-------
+_parse_tuple_or_scalar
+    scalar int/float returned as single-element tuple
+    tuple-string parsed correctly
+    NaN / unparseable value returned as (nan,)
+
+_resolve_xy_largest
+    single-segment rows: returns the scalar position unchanged
+    multi-segment rows: returns position of the largest segment
+
+_resolve_xy_weighted
+    single-segment: result equals the scalar position
+    multi-segment with equal areas: result is the simple mean
+    multi-segment: result is between the two endpoints
+    zero-area segments: no divide-by-zero
+
+_resolve_prop_largest / _resolve_prop_weighted
+    scalar passthrough
+    multi-segment: correct value selected / weighted
+
+_sum_segments_area
+    scalar rows: result equals the scalar
+    tuple rows: result equals the arithmetic sum
+
+_build_header / _read_csv_metadata
+    round-trip: written header parsed back to same dict
+
+_export_tracking_from_data
+    output file(s) created
+    pos_x / pos_y columns present and numeric
+    area column present and numeric
+    no centroid_x / centroid_y / segments_x / segments_y columns in output
+    "largest": single-segment pos_x == raw input
+    "largest": multi-segment pos_x == x of biggest segment
+    "largest": area == area of biggest segment
+    "weighted": pos_x between segment endpoints
+    "weighted": area == sum of segment areas
+    orientation always resolved via largest regardless of method
+    other regionprops resolved via chosen method
+    combined=False → one file per track
+    combined=True  → single all_tracks.csv
+    mask_com with zarr_root=None falls back gracefully
+    header metadata preserved in output
+
+export_tracking (public)
+    reads CSV, writes new CSV with correct column names
+    "largest" / "weighted" methods forwarded correctly
+    combined flag forwarded correctly
+    raises FileNotFoundError on missing CSVs
+"""
+
+import math
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from octron.tools.export_tracking import (
+    _build_header,
+    _export_tracking_from_data,
+    _parse_tuple_or_scalar,
+    _read_csv_metadata,
+    _resolve_prop_largest,
+    _resolve_prop_weighted,
+    _resolve_xy_largest,
+    _resolve_xy_weighted,
+    _sum_segments_area,
+    export_tracking,
+)
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+def _scalar_arr(*vals):
+    return np.array(vals, dtype=object)
+
+
+def _tup(t):
+    """Produce a tuple-string exactly as predict_batch writes it."""
+    return str(t)
+
+
+def _minimal_data(n=4, n_tracks=1):
+    """
+    Return the positional args needed by _export_tracking_from_data
+    (all single-segment scalar rows, no tuples).
+    """
+    tids   = list(range(n_tracks))
+    labels = {tid: "animal" for tid in tids}
+    fc     = {tid: np.arange(n) for tid in tids}
+    fi     = {tid: np.arange(n) for tid in tids}
+    conf   = {tid: np.full(n, 0.9) for tid in tids}
+    sx     = {tid: np.arange(n, dtype=float) for tid in tids}
+    sy     = {tid: np.arange(n, dtype=float) for tid in tids}
+    sa     = {tid: np.full(n, 100.0) for tid in tids}
+    bbox   = {tid: {
+        "bbox_x_min": np.zeros(n), "bbox_x_max": np.ones(n),
+        "bbox_y_min": np.zeros(n), "bbox_y_max": np.ones(n),
+        "bbox_area":  np.ones(n),  "bbox_aspect_ratio": np.ones(n),
+    } for tid in tids}
+    rp     = {tid: {} for tid in tids}
+    meta   = {
+        "video_name": "test.mp4", "frame_count": "100",
+        "frame_count_analyzed": str(n), "video_height": "480",
+        "video_width": "640",   "created_at": "2026-01-01 00:00:00",
+    }
+    return tids, labels, fc, fi, conf, sx, sy, sa, bbox, rp, meta
+
+
+def _read_output(tmp_path, filename="animal_track_0.csv"):
+    return pd.read_csv(tmp_path / filename, skiprows=7)
+
+
+# ===========================================================================
+# _parse_tuple_or_scalar
+# ===========================================================================
+
+def test_parse_scalar_int():
+    assert _parse_tuple_or_scalar(5) == (5.0,)
+
+def test_parse_scalar_float():
+    assert _parse_tuple_or_scalar(3.14) == pytest.approx((3.14,))
+
+def test_parse_two_element_tuple_string():
+    result = _parse_tuple_or_scalar("(10.5, 20.3)")
+    assert len(result) == 2
+    assert result[0] == pytest.approx(10.5)
+    assert result[1] == pytest.approx(20.3)
+
+def test_parse_single_element_tuple_string():
+    assert _parse_tuple_or_scalar("(42.0,)") == pytest.approx((42.0,))
+
+def test_parse_nan_string():
+    result = _parse_tuple_or_scalar("NaN")
+    assert len(result) == 1 and math.isnan(result[0])
+
+def test_parse_unparseable_string():
+    result = _parse_tuple_or_scalar("garbage")
+    assert len(result) == 1 and math.isnan(result[0])
+
+
+# ===========================================================================
+# _resolve_xy_largest
+# ===========================================================================
+
+def test_largest_single_segment_passthrough():
+    xs = _scalar_arr(10.0, 20.0)
+    ys = _scalar_arr( 5.0, 15.0)
+    sa = _scalar_arr(100.0, 200.0)
+    cx, cy = _resolve_xy_largest(xs, ys, sa)
+    assert cx == pytest.approx([10.0, 20.0])
+    assert cy == pytest.approx([ 5.0, 15.0])
+
+def test_largest_picks_first_when_biggest():
+    cx, _ = _resolve_xy_largest(
+        _scalar_arr(_tup((10.0, 90.0))),
+        _scalar_arr(_tup(( 5.0, 50.0))),
+        _scalar_arr(_tup((200.0, 50.0))),
+    )
+    assert cx[0] == pytest.approx(10.0)
+
+def test_largest_picks_second_when_biggest():
+    cx, cy = _resolve_xy_largest(
+        _scalar_arr(_tup((10.0, 90.0))),
+        _scalar_arr(_tup(( 5.0, 50.0))),
+        _scalar_arr(_tup(( 50.0, 300.0))),
+    )
+    assert cx[0] == pytest.approx(90.0)
+    assert cy[0] == pytest.approx(50.0)
+
+
+# ===========================================================================
+# _resolve_xy_weighted
+# ===========================================================================
+
+def test_weighted_single_segment_passthrough():
+    cx, cy = _resolve_xy_weighted(
+        _scalar_arr(10.0), _scalar_arr(5.0), _scalar_arr(100.0)
+    )
+    assert cx[0] == pytest.approx(10.0)
+    assert cy[0] == pytest.approx(5.0)
+
+def test_weighted_equal_areas_gives_mean():
+    cx, cy = _resolve_xy_weighted(
+        _scalar_arr(_tup((0.0, 100.0))),
+        _scalar_arr(_tup((0.0, 200.0))),
+        _scalar_arr(_tup((50.0, 50.0))),
+    )
+    assert cx[0] == pytest.approx(50.0)
+    assert cy[0] == pytest.approx(100.0)
+
+def test_weighted_result_between_endpoints():
+    cx, _ = _resolve_xy_weighted(
+        _scalar_arr(_tup((0.0, 100.0))),
+        _scalar_arr(_tup((0.0,   0.0))),
+        _scalar_arr(_tup((75.0, 25.0))),
+    )
+    assert 0.0 < cx[0] < 100.0
+
+def test_weighted_zero_area_no_error():
+    cx, _ = _resolve_xy_weighted(
+        _scalar_arr(_tup((0.0, 100.0))),
+        _scalar_arr(_tup((0.0,   0.0))),
+        _scalar_arr(_tup((0.0,   0.0))),
+    )
+    assert not math.isnan(cx[0])
+
+
+# ===========================================================================
+# _resolve_prop_largest / _resolve_prop_weighted
+# ===========================================================================
+
+def test_resolve_prop_largest_scalar_passthrough():
+    out = _resolve_prop_largest(_scalar_arr(0.8, 0.5), _scalar_arr(100.0, 200.0))
+    assert out == pytest.approx([0.8, 0.5])
+
+def test_resolve_prop_largest_picks_correct_index():
+    # areas (50, 300) → index 1 is largest
+    out = _resolve_prop_largest(
+        _scalar_arr(_tup((0.8, 0.4))),
+        _scalar_arr(_tup((50.0, 300.0))),
+    )
+    assert out[0] == pytest.approx(0.4)
+
+def test_resolve_prop_weighted_scalar_passthrough():
+    out = _resolve_prop_weighted(_scalar_arr(0.6, 0.9), _scalar_arr(100.0, 200.0))
+    assert out == pytest.approx([0.6, 0.9])
+
+def test_resolve_prop_weighted_equal_areas_is_mean():
+    out = _resolve_prop_weighted(
+        _scalar_arr(_tup((0.0, 1.0))),
+        _scalar_arr(_tup((50.0, 50.0))),
+    )
+    assert out[0] == pytest.approx(0.5)
+
+
+# ===========================================================================
+# _sum_segments_area
+# ===========================================================================
+
+def test_sum_area_scalar():
+    out = _sum_segments_area(_scalar_arr(100.0, 200.0))
+    assert out == pytest.approx([100.0, 200.0])
+
+def test_sum_area_tuples():
+    out = _sum_segments_area(_scalar_arr(_tup((200.0, 50.0)), _tup((10.0, 10.0, 5.0))))
+    assert out[0] == pytest.approx(250.0)
+    assert out[1] == pytest.approx(25.0)
+
+
+# ===========================================================================
+# _build_header / _read_csv_metadata  round-trip
+# ===========================================================================
+
+def test_header_round_trip(tmp_path):
+    meta = {
+        "video_name": "myvideo.mp4", "frame_count": "500",
+        "frame_count_analyzed": "250", "video_height": "720",
+        "video_width": "1280", "created_at": "2026-01-01 12:00:00",
+    }
+    p = tmp_path / "track.csv"
+    p.write_text(_build_header(meta) + "col1,col2\n1,2\n")
+    recovered = _read_csv_metadata(p, n_header_lines=7)
+    for key in meta:
+        assert recovered[key] == meta[key]
+
+
+# ===========================================================================
+# _export_tracking_from_data — column contract
+# ===========================================================================
+
+def test_export_output_has_pos_x_pos_y_area(tmp_path):
+    _export_tracking_from_data(tmp_path, *_minimal_data(), centroid_method="largest",
+                                zarr_root=None, combined=False)
+    df = _read_output(tmp_path)
+    for col in ("pos_x", "pos_y", "area"):
+        assert col in df.columns, f"Missing: {col}"
+
+def test_export_no_centroid_or_segments_columns(tmp_path):
+    _export_tracking_from_data(tmp_path, *_minimal_data(), centroid_method="largest",
+                                zarr_root=None, combined=False)
+    df = _read_output(tmp_path)
+    for col in ("centroid_x", "centroid_y", "segments_x", "segments_y", "segments_area"):
+        assert col not in df.columns, f"Unexpected column present: {col}"
+
+def test_export_pos_columns_are_numeric(tmp_path):
+    _export_tracking_from_data(tmp_path, *_minimal_data(), centroid_method="largest",
+                                zarr_root=None, combined=False)
+    df = _read_output(tmp_path)
+    assert pd.api.types.is_float_dtype(df["pos_x"])
+    assert pd.api.types.is_float_dtype(df["pos_y"])
+    assert pd.api.types.is_float_dtype(df["area"])
+
+def test_export_area_is_numeric(tmp_path):
+    _export_tracking_from_data(tmp_path, *_minimal_data(), centroid_method="weighted",
+                                zarr_root=None, combined=False)
+    df = _read_output(tmp_path)
+    assert pd.api.types.is_float_dtype(df["area"])
+
+
+# ===========================================================================
+# _export_tracking_from_data — centroid_method="largest"
+# ===========================================================================
+
+def test_largest_single_segment_pos_equals_input(tmp_path):
+    tids, labels, fc, fi, conf, sx, sy, sa, bbox, rp, meta = _minimal_data(n=4)
+    _export_tracking_from_data(tmp_path, tids, labels, fc, fi, conf, sx, sy, sa,
+                                bbox, rp, meta, centroid_method="largest",
+                                zarr_root=None, combined=False)
+    df = _read_output(tmp_path)
+    np.testing.assert_allclose(df["pos_x"].values, sx[0].astype(float))
+
+def test_largest_multi_segment_pos_x_picks_biggest(tmp_path):
+    tids, labels, fc, fi, conf, sx, sy, sa, bbox, rp, meta = _minimal_data(n=1)
+    # Second segment has larger area (300 vs 50) → pos_x should be 90
+    sx[0] = np.array([_tup((10.0, 90.0))], dtype=object)
+    sy[0] = np.array([_tup(( 5.0, 50.0))], dtype=object)
+    sa[0] = np.array([_tup((50.0, 300.0))], dtype=object)
+    _export_tracking_from_data(tmp_path, tids, labels, fc, fi, conf, sx, sy, sa,
+                                bbox, rp, meta, centroid_method="largest",
+                                zarr_root=None, combined=False)
+    df = _read_output(tmp_path)
+    assert df["pos_x"].iloc[0] == pytest.approx(90.0)
+
+def test_largest_area_is_area_of_biggest_segment(tmp_path):
+    tids, labels, fc, fi, conf, sx, sy, sa, bbox, rp, meta = _minimal_data(n=1)
+    sa[0] = np.array([_tup((50.0, 300.0))], dtype=object)
+    sx[0] = np.array([_tup((0.0, 0.0))], dtype=object)
+    sy[0] = np.array([_tup((0.0, 0.0))], dtype=object)
+    _export_tracking_from_data(tmp_path, tids, labels, fc, fi, conf, sx, sy, sa,
+                                bbox, rp, meta, centroid_method="largest",
+                                zarr_root=None, combined=False)
+    df = _read_output(tmp_path)
+    assert df["area"].iloc[0] == pytest.approx(300.0)
+
+
+# ===========================================================================
+# _export_tracking_from_data — centroid_method="weighted"
+# ===========================================================================
+
+def test_weighted_pos_x_between_segments(tmp_path):
+    tids, labels, fc, fi, conf, sx, sy, sa, bbox, rp, meta = _minimal_data(n=1)
+    sx[0] = np.array([_tup((0.0, 100.0))], dtype=object)
+    sy[0] = np.array([_tup((0.0,   0.0))], dtype=object)
+    sa[0] = np.array([_tup((75.0, 25.0))], dtype=object)
+    _export_tracking_from_data(tmp_path, tids, labels, fc, fi, conf, sx, sy, sa,
+                                bbox, rp, meta, centroid_method="weighted",
+                                zarr_root=None, combined=False)
+    df = _read_output(tmp_path)
+    assert 0.0 < df["pos_x"].iloc[0] < 100.0
+
+def test_weighted_area_is_sum_of_segments(tmp_path):
+    tids, labels, fc, fi, conf, sx, sy, sa, bbox, rp, meta = _minimal_data(n=1)
+    sa[0] = np.array([_tup((200.0, 50.0))], dtype=object)
+    sx[0] = np.array([_tup((0.0, 0.0))], dtype=object)
+    sy[0] = np.array([_tup((0.0, 0.0))], dtype=object)
+    _export_tracking_from_data(tmp_path, tids, labels, fc, fi, conf, sx, sy, sa,
+                                bbox, rp, meta, centroid_method="weighted",
+                                zarr_root=None, combined=False)
+    df = _read_output(tmp_path)
+    assert df["area"].iloc[0] == pytest.approx(250.0)
+
+
+# ===========================================================================
+# _export_tracking_from_data — regionprops resolution
+# ===========================================================================
+
+def test_regionprop_tuples_resolved_to_scalar(tmp_path):
+    tids, labels, fc, fi, conf, sx, sy, sa, bbox, rp, meta = _minimal_data(n=2)
+    sa[0] = np.array([_tup((200.0, 50.0)), 100.0], dtype=object)
+    rp[0] = {"solidity": np.array([_tup((0.9, 0.4)), 0.8], dtype=object)}
+    _export_tracking_from_data(tmp_path, tids, labels, fc, fi, conf, sx, sy, sa,
+                                bbox, rp, meta, centroid_method="largest",
+                                zarr_root=None, combined=False)
+    df = _read_output(tmp_path)
+    assert "solidity" in df.columns
+    assert pd.api.types.is_float_dtype(df["solidity"])
+    # largest segment has area 200 (index 0) → solidity should be 0.9
+    assert df["solidity"].iloc[0] == pytest.approx(0.9)
+
+def test_orientation_always_uses_largest_regardless_of_method(tmp_path):
+    """orientation is circular — must always come from the largest segment."""
+    for method in ("largest", "weighted"):
+        out = tmp_path / method
+        out.mkdir()
+        tids, labels, fc, fi, conf, sx, sy, sa, bbox, rp, meta = _minimal_data(n=1)
+        sa[0] = np.array([_tup((50.0, 300.0))], dtype=object)
+        sx[0] = np.array([_tup((0.0, 0.0))], dtype=object)
+        sy[0] = np.array([_tup((0.0, 0.0))], dtype=object)
+        # orientation values differ per segment
+        rp[0] = {"orientation": np.array([_tup((1.0, 2.0))], dtype=object)}
+        _export_tracking_from_data(out, tids, labels, fc, fi, conf, sx, sy, sa,
+                                    bbox, rp, meta, centroid_method=method,
+                                    zarr_root=None, combined=False)
+        df = pd.read_csv(out / "animal_track_0.csv", skiprows=7)
+        # second segment is largest (area 300 → index 1 → orientation 2.0)
+        assert df["orientation"].iloc[0] == pytest.approx(2.0), \
+            f"orientation wrong for method={method}"
+
+
+# ===========================================================================
+# _export_tracking_from_data — file-writing
+# ===========================================================================
+
+def test_export_per_track_files(tmp_path):
+    _export_tracking_from_data(tmp_path, *_minimal_data(n_tracks=2),
+                                centroid_method="largest", zarr_root=None, combined=False)
+    assert (tmp_path / "animal_track_0.csv").exists()
+    assert (tmp_path / "animal_track_1.csv").exists()
+
+def test_export_combined_file(tmp_path):
+    _export_tracking_from_data(tmp_path, *_minimal_data(n_tracks=2),
+                                centroid_method="largest", zarr_root=None, combined=True)
+    assert (tmp_path / "all_tracks.csv").exists()
+    assert not (tmp_path / "animal_track_0.csv").exists()
+
+def test_export_combined_contains_all_tracks(tmp_path):
+    _export_tracking_from_data(tmp_path, *_minimal_data(n_tracks=3),
+                                centroid_method="largest", zarr_root=None, combined=True)
+    df = pd.read_csv(tmp_path / "all_tracks.csv", skiprows=7)
+    assert set(df["track_id"].unique()) == {0, 1, 2}
+
+def test_export_mask_com_fallback_no_error(tmp_path):
+    _export_tracking_from_data(tmp_path, *_minimal_data(),
+                                centroid_method="mask_com", zarr_root=None, combined=False)
+    df = _read_output(tmp_path)
+    assert "pos_x" in df.columns
+    assert not df["pos_x"].isna().all()
+
+def test_export_header_preserved(tmp_path):
+    _export_tracking_from_data(tmp_path, *_minimal_data(),
+                                centroid_method="largest", zarr_root=None, combined=False)
+    meta = _read_csv_metadata(tmp_path / "animal_track_0.csv")
+    assert meta["video_name"] == "test.mp4"
+    assert meta["video_height"] == "480"
+
+
+# ===========================================================================
+# export_tracking  (public)
+# ===========================================================================
+
+def _write_prediction_csv(path, track_id, label="animal", n=4):
+    """Write a CSV in the format produced by _export_tracking_from_data."""
+    from octron.tools.export_tracking import _build_header
+    meta = {
+        "video_name": "vid.mp4", "frame_count": "100",
+        "frame_count_analyzed": str(n), "video_height": "480",
+        "video_width": "640",   "created_at": "2026-01-01 00:00:00",
+    }
+    df = pd.DataFrame({
+        "frame_counter":    np.arange(n),
+        "frame_idx":        np.arange(n),
+        "track_id":         track_id,
+        "label":            label,
+        "confidence":       0.9,
+        "pos_x":            np.arange(n, dtype=float),
+        "pos_y":            np.arange(n, dtype=float),
+        "bbox_x_min":       0.0, "bbox_x_max": 1.0,
+        "bbox_y_min":       0.0, "bbox_y_max": 1.0,
+        "bbox_area":        1.0, "bbox_aspect_ratio": 1.0,
+        "area":             100.0,
+    })
+    with open(path, "w") as f:
+        f.write(_build_header(meta))
+        df.to_csv(f, index=False, lineterminator="\n")
+
+
+def test_public_export_creates_output(tmp_path):
+    _write_prediction_csv(tmp_path / "animal_track_1.csv", track_id=1)
+    export_tracking(tmp_path, output_dir=tmp_path)
+    assert (tmp_path / "animal_track_1.csv").exists()
+
+def test_public_export_output_has_pos_and_area(tmp_path):
+    _write_prediction_csv(tmp_path / "animal_track_1.csv", track_id=1)
+    export_tracking(tmp_path, output_dir=tmp_path)
+    df = pd.read_csv(tmp_path / "animal_track_1.csv", skiprows=7)
+    assert "pos_x" in df.columns
+    assert "area" in df.columns
+
+def test_public_export_no_spurious_columns(tmp_path):
+    _write_prediction_csv(tmp_path / "animal_track_1.csv", track_id=1)
+    export_tracking(tmp_path, output_dir=tmp_path)
+    df = pd.read_csv(tmp_path / "animal_track_1.csv", skiprows=7)
+    for col in ("centroid_x", "centroid_y", "segments_x", "segments_y", "segments_area"):
+        assert col not in df.columns
+
+def test_public_export_combined(tmp_path):
+    _write_prediction_csv(tmp_path / "animal_track_1.csv", track_id=1)
+    _write_prediction_csv(tmp_path / "animal_track_2.csv", track_id=2)
+    export_tracking(tmp_path, output_dir=tmp_path, combined=True)
+    assert (tmp_path / "all_tracks.csv").exists()
+
+def test_public_export_region_properties_filter(tmp_path):
+    csv_path = tmp_path / "animal_track_1.csv"
+    _write_prediction_csv(csv_path, track_id=1)
+    # Append extra regionprop columns
+    df = pd.read_csv(csv_path, skiprows=7)
+    df["eccentricity"] = 0.5
+    df["solidity"]     = 0.8
+    meta = _read_csv_metadata(csv_path)
+    from octron.tools.export_tracking import _build_header
+    with open(csv_path, "w") as f:
+        f.write(_build_header(meta))
+        df.to_csv(f, index=False, lineterminator="\n")
+
+    export_tracking(tmp_path, output_dir=tmp_path, region_properties=["eccentricity"])
+    out = pd.read_csv(csv_path, skiprows=7)
+    assert "eccentricity" in out.columns
+    assert "solidity" not in out.columns
+
+def test_public_export_raises_on_missing_csvs(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        export_tracking(tmp_path / "nonexistent")

--- a/tests/test_export_tracking.py
+++ b/tests/test_export_tracking.py
@@ -487,19 +487,19 @@ def _write_prediction_csv(path, track_id, label="animal", n=4):
 
 def test_public_export_creates_output(tmp_path):
     _write_prediction_csv(tmp_path / "animal_track_1.csv", track_id=1)
-    export_tracking(tmp_path, output_dir=tmp_path)
+    export_tracking(tmp_path, output_dir=tmp_path, overwrite=True)
     assert (tmp_path / "animal_track_1.csv").exists()
 
 def test_public_export_output_has_pos_and_area(tmp_path):
     _write_prediction_csv(tmp_path / "animal_track_1.csv", track_id=1)
-    export_tracking(tmp_path, output_dir=tmp_path)
+    export_tracking(tmp_path, output_dir=tmp_path, overwrite=True)
     df = pd.read_csv(tmp_path / "animal_track_1.csv", skiprows=7)
     assert "pos_x" in df.columns
     assert "area" in df.columns
 
 def test_public_export_no_spurious_columns(tmp_path):
     _write_prediction_csv(tmp_path / "animal_track_1.csv", track_id=1)
-    export_tracking(tmp_path, output_dir=tmp_path)
+    export_tracking(tmp_path, output_dir=tmp_path, overwrite=True)
     df = pd.read_csv(tmp_path / "animal_track_1.csv", skiprows=7)
     for col in ("centroid_x", "centroid_y", "segments_x", "segments_y", "segments_area"):
         assert col not in df.columns
@@ -523,7 +523,7 @@ def test_public_export_region_properties_filter(tmp_path):
         f.write(_build_header(meta))
         df.to_csv(f, index=False, lineterminator="\n")
 
-    export_tracking(tmp_path, output_dir=tmp_path, region_properties=["eccentricity"])
+    export_tracking(tmp_path, output_dir=tmp_path, region_properties=["eccentricity"], overwrite=True)
     out = pd.read_csv(csv_path, skiprows=7)
     assert "eccentricity" in out.columns
     assert "solidity" not in out.columns
@@ -531,3 +531,42 @@ def test_public_export_region_properties_filter(tmp_path):
 def test_public_export_raises_on_missing_csvs(tmp_path):
     with pytest.raises(FileNotFoundError):
         export_tracking(tmp_path / "nonexistent")
+
+
+# ===========================================================================
+# export_tracking — overwrite guard
+# ===========================================================================
+
+def test_overwrite_false_raises_when_file_exists(tmp_path):
+    """Default overwrite=False should raise FileExistsError if output exists."""
+    _write_prediction_csv(tmp_path / "animal_track_1.csv", track_id=1)
+    # First export creates the file
+    export_tracking(tmp_path, output_dir=tmp_path, overwrite=True)
+    # Second export without overwrite should fail
+    with pytest.raises(FileExistsError):
+        export_tracking(tmp_path, output_dir=tmp_path, overwrite=False)
+
+
+def test_overwrite_true_replaces_existing_file(tmp_path):
+    """overwrite=True should silently replace an existing output file."""
+    _write_prediction_csv(tmp_path / "animal_track_1.csv", track_id=1)
+    export_tracking(tmp_path, output_dir=tmp_path, overwrite=True)
+    export_tracking(tmp_path, output_dir=tmp_path, overwrite=True)  # no error
+    assert (tmp_path / "animal_track_1.csv").exists()
+
+
+def test_overwrite_false_raises_for_combined(tmp_path):
+    """overwrite=False should raise when all_tracks.csv already exists."""
+    _write_prediction_csv(tmp_path / "animal_track_1.csv", track_id=1)
+    export_tracking(tmp_path, output_dir=tmp_path, combined=True, overwrite=True)
+    with pytest.raises(FileExistsError):
+        export_tracking(tmp_path, output_dir=tmp_path, combined=True, overwrite=False)
+
+
+def test_overwrite_false_no_error_when_output_dir_is_different(tmp_path):
+    """No error when writing to a fresh directory even with overwrite=False."""
+    _write_prediction_csv(tmp_path / "animal_track_1.csv", track_id=1)
+    out = tmp_path / "fresh"
+    out.mkdir()
+    export_tracking(tmp_path, output_dir=out, overwrite=False)  # should not raise
+    assert (out / "animal_track_1.csv").exists()

--- a/tests/test_export_tracking.py
+++ b/tests/test_export_tracking.py
@@ -290,21 +290,21 @@ def test_header_round_trip(tmp_path):
 # ===========================================================================
 
 def test_export_output_has_pos_x_pos_y_area(tmp_path):
-    _export_tracking_from_data(tmp_path, *_minimal_data(), centroid_method="largest",
+    _export_tracking_from_data(tmp_path, *_minimal_data(), method="largest",
                                 zarr_root=None, combined=False)
     df = _read_output(tmp_path)
     for col in ("pos_x", "pos_y", "area"):
         assert col in df.columns, f"Missing: {col}"
 
 def test_export_no_centroid_or_segments_columns(tmp_path):
-    _export_tracking_from_data(tmp_path, *_minimal_data(), centroid_method="largest",
+    _export_tracking_from_data(tmp_path, *_minimal_data(), method="largest",
                                 zarr_root=None, combined=False)
     df = _read_output(tmp_path)
     for col in ("centroid_x", "centroid_y", "segments_x", "segments_y", "segments_area"):
         assert col not in df.columns, f"Unexpected column present: {col}"
 
 def test_export_pos_columns_are_numeric(tmp_path):
-    _export_tracking_from_data(tmp_path, *_minimal_data(), centroid_method="largest",
+    _export_tracking_from_data(tmp_path, *_minimal_data(), method="largest",
                                 zarr_root=None, combined=False)
     df = _read_output(tmp_path)
     assert pd.api.types.is_float_dtype(df["pos_x"])
@@ -312,20 +312,20 @@ def test_export_pos_columns_are_numeric(tmp_path):
     assert pd.api.types.is_float_dtype(df["area"])
 
 def test_export_area_is_numeric(tmp_path):
-    _export_tracking_from_data(tmp_path, *_minimal_data(), centroid_method="weighted",
+    _export_tracking_from_data(tmp_path, *_minimal_data(), method="weighted",
                                 zarr_root=None, combined=False)
     df = _read_output(tmp_path)
     assert pd.api.types.is_float_dtype(df["area"])
 
 
 # ===========================================================================
-# _export_tracking_from_data — centroid_method="largest"
+# _export_tracking_from_data — method="largest"
 # ===========================================================================
 
 def test_largest_single_segment_pos_equals_input(tmp_path):
     tids, labels, fc, fi, conf, sx, sy, sa, bbox, rp, meta = _minimal_data(n=4)
     _export_tracking_from_data(tmp_path, tids, labels, fc, fi, conf, sx, sy, sa,
-                                bbox, rp, meta, centroid_method="largest",
+                                bbox, rp, meta, method="largest",
                                 zarr_root=None, combined=False)
     df = _read_output(tmp_path)
     np.testing.assert_allclose(df["pos_x"].values, sx[0].astype(float))
@@ -337,7 +337,7 @@ def test_largest_multi_segment_pos_x_picks_biggest(tmp_path):
     sy[0] = np.array([_tup(( 5.0, 50.0))], dtype=object)
     sa[0] = np.array([_tup((50.0, 300.0))], dtype=object)
     _export_tracking_from_data(tmp_path, tids, labels, fc, fi, conf, sx, sy, sa,
-                                bbox, rp, meta, centroid_method="largest",
+                                bbox, rp, meta, method="largest",
                                 zarr_root=None, combined=False)
     df = _read_output(tmp_path)
     assert df["pos_x"].iloc[0] == pytest.approx(90.0)
@@ -348,14 +348,14 @@ def test_largest_area_is_area_of_biggest_segment(tmp_path):
     sx[0] = np.array([_tup((0.0, 0.0))], dtype=object)
     sy[0] = np.array([_tup((0.0, 0.0))], dtype=object)
     _export_tracking_from_data(tmp_path, tids, labels, fc, fi, conf, sx, sy, sa,
-                                bbox, rp, meta, centroid_method="largest",
+                                bbox, rp, meta, method="largest",
                                 zarr_root=None, combined=False)
     df = _read_output(tmp_path)
     assert df["area"].iloc[0] == pytest.approx(300.0)
 
 
 # ===========================================================================
-# _export_tracking_from_data — centroid_method="weighted"
+# _export_tracking_from_data — method="weighted"
 # ===========================================================================
 
 def test_weighted_pos_x_between_segments(tmp_path):
@@ -364,7 +364,7 @@ def test_weighted_pos_x_between_segments(tmp_path):
     sy[0] = np.array([_tup((0.0,   0.0))], dtype=object)
     sa[0] = np.array([_tup((75.0, 25.0))], dtype=object)
     _export_tracking_from_data(tmp_path, tids, labels, fc, fi, conf, sx, sy, sa,
-                                bbox, rp, meta, centroid_method="weighted",
+                                bbox, rp, meta, method="weighted",
                                 zarr_root=None, combined=False)
     df = _read_output(tmp_path)
     assert 0.0 < df["pos_x"].iloc[0] < 100.0
@@ -375,7 +375,7 @@ def test_weighted_area_is_sum_of_segments(tmp_path):
     sx[0] = np.array([_tup((0.0, 0.0))], dtype=object)
     sy[0] = np.array([_tup((0.0, 0.0))], dtype=object)
     _export_tracking_from_data(tmp_path, tids, labels, fc, fi, conf, sx, sy, sa,
-                                bbox, rp, meta, centroid_method="weighted",
+                                bbox, rp, meta, method="weighted",
                                 zarr_root=None, combined=False)
     df = _read_output(tmp_path)
     assert df["area"].iloc[0] == pytest.approx(250.0)
@@ -390,7 +390,7 @@ def test_regionprop_tuples_resolved_to_scalar(tmp_path):
     sa[0] = np.array([_tup((200.0, 50.0)), 100.0], dtype=object)
     rp[0] = {"solidity": np.array([_tup((0.9, 0.4)), 0.8], dtype=object)}
     _export_tracking_from_data(tmp_path, tids, labels, fc, fi, conf, sx, sy, sa,
-                                bbox, rp, meta, centroid_method="largest",
+                                bbox, rp, meta, method="largest",
                                 zarr_root=None, combined=False)
     df = _read_output(tmp_path)
     assert "solidity" in df.columns
@@ -410,7 +410,7 @@ def test_orientation_always_uses_largest_regardless_of_method(tmp_path):
         # orientation values differ per segment
         rp[0] = {"orientation": np.array([_tup((1.0, 2.0))], dtype=object)}
         _export_tracking_from_data(out, tids, labels, fc, fi, conf, sx, sy, sa,
-                                    bbox, rp, meta, centroid_method=method,
+                                    bbox, rp, meta, method=method,
                                     zarr_root=None, combined=False)
         df = pd.read_csv(out / "animal_track_0.csv", skiprows=7)
         # second segment is largest (area 300 → index 1 → orientation 2.0)
@@ -424,32 +424,32 @@ def test_orientation_always_uses_largest_regardless_of_method(tmp_path):
 
 def test_export_per_track_files(tmp_path):
     _export_tracking_from_data(tmp_path, *_minimal_data(n_tracks=2),
-                                centroid_method="largest", zarr_root=None, combined=False)
+                                method="largest", zarr_root=None, combined=False)
     assert (tmp_path / "animal_track_0.csv").exists()
     assert (tmp_path / "animal_track_1.csv").exists()
 
 def test_export_combined_file(tmp_path):
     _export_tracking_from_data(tmp_path, *_minimal_data(n_tracks=2),
-                                centroid_method="largest", zarr_root=None, combined=True)
+                                method="largest", zarr_root=None, combined=True)
     assert (tmp_path / "all_tracks.csv").exists()
     assert not (tmp_path / "animal_track_0.csv").exists()
 
 def test_export_combined_contains_all_tracks(tmp_path):
     _export_tracking_from_data(tmp_path, *_minimal_data(n_tracks=3),
-                                centroid_method="largest", zarr_root=None, combined=True)
+                                method="largest", zarr_root=None, combined=True)
     df = pd.read_csv(tmp_path / "all_tracks.csv", skiprows=7)
     assert set(df["track_id"].unique()) == {0, 1, 2}
 
 def test_export_mask_com_fallback_no_error(tmp_path):
     _export_tracking_from_data(tmp_path, *_minimal_data(),
-                                centroid_method="mask_com", zarr_root=None, combined=False)
+                                method="mask_com", zarr_root=None, combined=False)
     df = _read_output(tmp_path)
     assert "pos_x" in df.columns
     assert not df["pos_x"].isna().all()
 
 def test_export_header_preserved(tmp_path):
     _export_tracking_from_data(tmp_path, *_minimal_data(),
-                                centroid_method="largest", zarr_root=None, combined=False)
+                                method="largest", zarr_root=None, combined=False)
     meta = _read_csv_metadata(tmp_path / "animal_track_0.csv")
     assert meta["video_name"] == "test.mp4"
     assert meta["video_height"] == "480"
@@ -543,7 +543,9 @@ def test_public_export_region_properties_none_strips_extras(tmp_path):
     out = pd.read_csv(csv_path, skiprows=7)
     assert "eccentricity" not in out.columns
 
-def test_public_export_region_properties_all_keeps_extras(tmp_path):
+def test_public_export_region_properties_all_computes_all(tmp_path):
+    # "all" expands to every known property; without zarr, only columns already
+    # in the CSV (that are in ALL_REGION_PROPERTIES) survive the filter.
     csv_path = tmp_path / "animal_track_1.csv"
     _write_prediction_csv(csv_path, track_id=1)
     df = pd.read_csv(csv_path, skiprows=7)
@@ -584,6 +586,34 @@ def test_public_export_region_properties_intensity_alias(tmp_path):
     out = pd.read_csv(csv_path, skiprows=7)
     assert "intensity_mean" in out.columns
     assert "eccentricity" not in out.columns
+
+def test_zarr_regionprops_computed_when_missing_from_csv(tmp_path):
+    """Properties not in the CSV are computed from zarr masks at export time."""
+    import zarr, numpy as np
+
+    # Write a CSV with no extra regionprop columns
+    csv_path = tmp_path / "animal_track_1.csv"
+    _write_prediction_csv(csv_path, track_id=1)
+    df = pd.read_csv(csv_path, skiprows=7)
+    n = len(df)
+
+    # Build a minimal zarr archive with a small binary mask per frame
+    store_path = tmp_path / "predictions.zarr"
+    store = zarr.storage.LocalStore(str(store_path))
+    root = zarr.open_group(store=store, mode="w")
+    H, W = 64, 64
+    masks = np.zeros((n, H, W), dtype=np.int8)
+    for i in range(n):
+        masks[i, 10:30, 10:30] = 1  # 20×20 square object
+    arr = root.require_array("1_masks", shape=(n, H, W), dtype=np.int8)
+    arr[:] = masks
+    arr.attrs["video_height"] = H
+    arr.attrs["video_width"] = W
+
+    export_tracking(tmp_path, output_dir=tmp_path, region_properties=["eccentricity"], overwrite=True)
+    out = pd.read_csv(csv_path, skiprows=7)
+    assert "eccentricity" in out.columns
+    assert out["eccentricity"].notna().all()
 
 def test_public_export_raises_on_missing_csvs(tmp_path):
     with pytest.raises(FileNotFoundError):

--- a/tests/test_export_tracking.py
+++ b/tests/test_export_tracking.py
@@ -528,6 +528,36 @@ def test_public_export_region_properties_filter(tmp_path):
     assert "eccentricity" in out.columns
     assert "solidity" not in out.columns
 
+def test_public_export_region_properties_none_strips_extras(tmp_path):
+    csv_path = tmp_path / "animal_track_1.csv"
+    _write_prediction_csv(csv_path, track_id=1)
+    df = pd.read_csv(csv_path, skiprows=7)
+    df["eccentricity"] = 0.5
+    meta = _read_csv_metadata(csv_path)
+    from octron.tools.export_tracking import _build_header
+    with open(csv_path, "w") as f:
+        f.write(_build_header(meta))
+        df.to_csv(f, index=False, lineterminator="\n")
+
+    export_tracking(tmp_path, output_dir=tmp_path, region_properties="none", overwrite=True)
+    out = pd.read_csv(csv_path, skiprows=7)
+    assert "eccentricity" not in out.columns
+
+def test_public_export_region_properties_all_keeps_extras(tmp_path):
+    csv_path = tmp_path / "animal_track_1.csv"
+    _write_prediction_csv(csv_path, track_id=1)
+    df = pd.read_csv(csv_path, skiprows=7)
+    df["eccentricity"] = 0.5
+    meta = _read_csv_metadata(csv_path)
+    from octron.tools.export_tracking import _build_header
+    with open(csv_path, "w") as f:
+        f.write(_build_header(meta))
+        df.to_csv(f, index=False, lineterminator="\n")
+
+    export_tracking(tmp_path, output_dir=tmp_path, region_properties="all", overwrite=True)
+    out = pd.read_csv(csv_path, skiprows=7)
+    assert "eccentricity" in out.columns
+
 def test_public_export_raises_on_missing_csvs(tmp_path):
     with pytest.raises(FileNotFoundError):
         export_tracking(tmp_path / "nonexistent")

--- a/tests/test_export_tracking.py
+++ b/tests/test_export_tracking.py
@@ -558,6 +558,33 @@ def test_public_export_region_properties_all_keeps_extras(tmp_path):
     out = pd.read_csv(csv_path, skiprows=7)
     assert "eccentricity" in out.columns
 
+def _write_csv_with_extras(tmp_path, extras: dict):
+    csv_path = tmp_path / "animal_track_1.csv"
+    _write_prediction_csv(csv_path, track_id=1)
+    df = pd.read_csv(csv_path, skiprows=7)
+    for col, val in extras.items():
+        df[col] = val
+    meta = _read_csv_metadata(csv_path)
+    from octron.tools.export_tracking import _build_header
+    with open(csv_path, "w") as f:
+        f.write(_build_header(meta))
+        df.to_csv(f, index=False, lineterminator="\n")
+    return csv_path
+
+def test_public_export_region_properties_shape_alias(tmp_path):
+    csv_path = _write_csv_with_extras(tmp_path, {"eccentricity": 0.5, "intensity_mean": 100.0})
+    export_tracking(tmp_path, output_dir=tmp_path, region_properties="shape", overwrite=True)
+    out = pd.read_csv(csv_path, skiprows=7)
+    assert "eccentricity" in out.columns
+    assert "intensity_mean" not in out.columns
+
+def test_public_export_region_properties_intensity_alias(tmp_path):
+    csv_path = _write_csv_with_extras(tmp_path, {"eccentricity": 0.5, "intensity_mean": 100.0})
+    export_tracking(tmp_path, output_dir=tmp_path, region_properties="intensity", overwrite=True)
+    out = pd.read_csv(csv_path, skiprows=7)
+    assert "intensity_mean" in out.columns
+    assert "eccentricity" not in out.columns
+
 def test_public_export_raises_on_missing_csvs(tmp_path):
     with pytest.raises(FileNotFoundError):
         export_tracking(tmp_path / "nonexistent")

--- a/tests/test_export_tracking.py
+++ b/tests/test_export_tracking.py
@@ -823,3 +823,167 @@ def test_overwrite_false_no_error_when_output_dir_is_different(tmp_path):
     out.mkdir()
     export_tracking(tmp_path, output_dir=out, overwrite=False)  # should not raise
     assert (out / "animal_track_1.csv").exists()
+
+
+# ===========================================================================
+# Column renaming  (skimage '-N' suffixes → readable labels)
+# ===========================================================================
+
+def test_rename_intensity_channel_suffix():
+    from octron.tools.export_tracking import _rename_prop_column
+    assert _rename_prop_column("intensity_mean-0", has_intensity=True) == "intensity_mean_r"
+    assert _rename_prop_column("intensity_mean-1", has_intensity=True) == "intensity_mean_g"
+    assert _rename_prop_column("intensity_mean-2", has_intensity=True) == "intensity_mean_b"
+    assert _rename_prop_column("intensity_mean-3", has_intensity=True) == "intensity_mean_lum"
+
+
+def test_rename_weighted_centroid_axis_channel():
+    from octron.tools.export_tracking import _rename_prop_column
+    assert _rename_prop_column("weighted_centroid-0-0", True) == "weighted_centroid_y_r"
+    assert _rename_prop_column("weighted_centroid-0-1", True) == "weighted_centroid_y_g"
+    assert _rename_prop_column("weighted_centroid-0-2", True) == "weighted_centroid_y_b"
+    assert _rename_prop_column("weighted_centroid-0-3", True) == "weighted_centroid_y_lum"
+    assert _rename_prop_column("weighted_centroid-1-0", True) == "weighted_centroid_x_r"
+    assert _rename_prop_column("weighted_centroid-1-3", True) == "weighted_centroid_x_lum"
+
+
+def test_rename_centroid_axis_only():
+    from octron.tools.export_tracking import _rename_prop_column
+    assert _rename_prop_column("centroid-0", has_intensity=False) == "centroid_y"
+    assert _rename_prop_column("centroid-1", has_intensity=False) == "centroid_x"
+
+
+def test_rename_moments_hu_unchanged():
+    from octron.tools.export_tracking import _rename_prop_column
+    assert _rename_prop_column("moments_hu-0", has_intensity=False) == "moments_hu-0"
+    assert _rename_prop_column("moments_hu-6", has_intensity=False) == "moments_hu-6"
+
+
+def test_rename_bare_property_unchanged():
+    from octron.tools.export_tracking import _rename_prop_column
+    assert _rename_prop_column("eccentricity", has_intensity=False) == "eccentricity"
+    assert _rename_prop_column("solidity", has_intensity=True) == "solidity"
+
+
+# ===========================================================================
+# Bbox-offset correction for translation-variant regionprops
+# ===========================================================================
+
+def _build_synthetic_mask_and_intensity(H=64, W=64, y0=10, x0=12, h=20, w=24):
+    """Build a binary mask with a single rectangular region + 4-channel intensity."""
+    mask = np.zeros((H, W), dtype=np.int8)
+    mask[y0:y0+h, x0:x0+w] = 1
+    rng = np.random.default_rng(42)
+    # 4 channels (R, G, B, lum) — random integers in 0..255
+    intensity = rng.integers(0, 256, size=(H, W, 4), dtype=np.int32).astype(np.uint8)
+    return mask, intensity
+
+
+def test_weighted_centroid_bbox_offset_matches_full_image():
+    """Cropping then offsetting must match running on the full image."""
+    from skimage import measure
+    from octron.tools.export_tracking import _TRANSLATION_VARIANT_PROPS
+
+    H, W, y0, x0, h, w = 64, 64, 10, 12, 20, 24
+    mask, intensity = _build_synthetic_mask_and_intensity(H, W, y0, x0, h, w)
+
+    properties = ["weighted_centroid", "centroid", "area", "intensity_mean"]
+
+    # Full-image (correct reference)
+    full_labeled = measure.label(mask, background=0, connectivity=2)
+    full = measure.regionprops_table(
+        full_labeled, intensity_image=intensity, properties=properties
+    )
+
+    # Cropped (would silently shift values for variant props)
+    rows_any = mask.any(axis=1); cols_any = mask.any(axis=0)
+    r0 = int(rows_any.argmax())
+    r1 = int(len(rows_any) - rows_any[::-1].argmax())
+    c0 = int(cols_any.argmax())
+    c1 = int(len(cols_any) - cols_any[::-1].argmax())
+
+    crop_labeled = measure.label(mask[r0:r1, c0:c1], background=0, connectivity=2)
+    cropped = measure.regionprops_table(
+        crop_labeled, intensity_image=intensity[r0:r1, c0:c1],
+        properties=properties,
+    )
+
+    # Apply the same offset correction the worker does.
+    for col_key, vals in list(cropped.items()):
+        base = col_key.split("-")[0]
+        if base not in _TRANSLATION_VARIANT_PROPS:
+            continue
+        ax_idx = int(col_key.split("-")[1])
+        offset = r0 if ax_idx == 0 else c0
+        cropped[col_key] = vals + offset
+
+    for col_key in full:
+        np.testing.assert_allclose(
+            cropped[col_key], full[col_key], rtol=1e-6, atol=1e-6,
+            err_msg=f"Mismatch in column {col_key} after offset correction",
+        )
+
+
+def test_weighted_centroid_displacement_signal():
+    """R-channel intensity on the LEFT, B-channel on the RIGHT —
+    weighted_centroid_x_r must lie left of weighted_centroid_x_b."""
+    from skimage import measure
+
+    H, W = 32, 64
+    mask = np.zeros((H, W), dtype=np.int8)
+    mask[8:24, 8:56] = 1
+    intensity = np.zeros((H, W, 4), dtype=np.uint8)
+    intensity[:, :W // 2, 0] = 200    # R bright on the left
+    intensity[:, W // 2:, 2] = 200    # B bright on the right
+
+    labeled = measure.label(mask, background=0, connectivity=2)
+    out = measure.regionprops_table(
+        labeled, intensity_image=intensity, properties=["weighted_centroid"]
+    )
+    # axis-1 (x) channel-0 (R) and channel-2 (B)
+    x_r = out["weighted_centroid-1-0"][0]
+    x_b = out["weighted_centroid-1-2"][0]
+    assert x_r < x_b, f"Expected R-weighted x ({x_r}) < B-weighted x ({x_b})"
+
+
+# ===========================================================================
+# _ordered_columns expansion
+# ===========================================================================
+
+def test_ordered_columns_includes_axis_channel_expansions():
+    from octron.tools.export_tracking import _ordered_columns
+
+    cols = [
+        "label", "confidence", "pos_x", "pos_y", "area",
+        "weighted_centroid_y_r", "weighted_centroid_x_r",
+        "weighted_centroid_y_lum", "weighted_centroid_x_lum",
+        "intensity_mean_r", "intensity_mean_lum",
+        "eccentricity",
+    ]
+    ordered = _ordered_columns(cols)
+    # Every input column survives the ordering step.
+    assert set(ordered) == set(cols)
+    # Channel-only intensity expansion comes before axis-channel expansion
+    # (intensity_mean before weighted_centroid in ALL_REGION_PROPERTIES order).
+    assert ordered.index("intensity_mean_r") < ordered.index("weighted_centroid_y_r")
+    # Within weighted_centroid, axis-y comes before axis-x.
+    assert ordered.index("weighted_centroid_y_r") < ordered.index("weighted_centroid_x_r")
+
+
+def test_translation_variant_set_classification():
+    """Defensive: shape props should NOT be in the variant set; the variant
+    set must contain centroid and weighted_centroid."""
+    from octron.tools.export_tracking import _TRANSLATION_VARIANT_PROPS, _INTENSITY_PROPS
+    from octron.yolo_octron.constants import ALL_REGION_PROPERTIES
+
+    assert "centroid" in _TRANSLATION_VARIANT_PROPS
+    assert "weighted_centroid" in _TRANSLATION_VARIANT_PROPS
+
+    shape_props = set(ALL_REGION_PROPERTIES["Size and Shape"])
+    # None of the size/shape props should be flagged variant — they are all
+    # translation-invariant (eccentricity, perimeter, moments_hu, …).
+    assert shape_props.isdisjoint(_TRANSLATION_VARIANT_PROPS)
+
+    # weighted_centroid requires intensity_image — ensure it's flagged so
+    # the no-video early-skip filter excludes it correctly.
+    assert "weighted_centroid" in _INTENSITY_PROPS

--- a/tests/test_export_tracking.py
+++ b/tests/test_export_tracking.py
@@ -970,6 +970,149 @@ def test_ordered_columns_includes_axis_channel_expansions():
     assert ordered.index("weighted_centroid_y_r") < ordered.index("weighted_centroid_x_r")
 
 
+# ===========================================================================
+# Intensity-weighted spread (weighted_var_y / weighted_var_x / weighted_cov_yx)
+# ===========================================================================
+
+def _weighted_var_xy_reference(intensity_2d):
+    """Reference μ_20/μ_00 and μ_02/μ_00 over the full image, single channel."""
+    H, W = intensity_2d.shape
+    yy, xx = np.mgrid[:H, :W].astype(float)
+    I = intensity_2d.astype(float)
+    m00 = I.sum()
+    cy = (yy * I).sum() / m00
+    cx = (xx * I).sum() / m00
+    var_y = ((yy - cy) ** 2 * I).sum() / m00
+    var_x = ((xx - cx) ** 2 * I).sum() / m00
+    cov_yx = ((yy - cy) * (xx - cx) * I).sum() / m00
+    return var_y, var_x, cov_yx
+
+
+def test_weighted_var_matches_manual_reference():
+    """Pseudo-prop derivation in the worker post-process must match a hand-rolled
+    intensity-weighted variance/covariance computation."""
+    from skimage import measure
+    from octron.tools.export_tracking import _SPREAD_FROM_MOMENT
+
+    H, W = 40, 60
+    mask = np.zeros((H, W), dtype=np.int8)
+    mask[5:35, 8:52] = 1
+
+    rng = np.random.default_rng(0)
+    intensity_1ch = rng.integers(50, 200, size=(H, W), dtype=np.int32).astype(np.uint8)
+
+    # Multi-channel image with the same data on the R channel; other channels
+    # left at zero so we focus on a single channel comparison.
+    intensity = np.zeros((H, W, 4), dtype=np.uint8)
+    intensity[..., 0] = intensity_1ch  # R
+
+    var_y_ref, var_x_ref, cov_yx_ref = _weighted_var_xy_reference(
+        intensity_1ch * mask
+    )
+
+    labeled = measure.label(mask, background=0, connectivity=2)
+    raw = measure.regionprops_table(
+        labeled, intensity_image=intensity,
+        properties=["weighted_moments_central"],
+    )
+    # Replicate the worker's derivation for channel 0.
+    m00 = raw["weighted_moments_central-0-0-0"][0]
+    derived = {}
+    for (i, j), base in _SPREAD_FROM_MOMENT.items():
+        derived[base] = raw[f"weighted_moments_central-{i}-{j}-0"][0] / m00
+
+    assert derived["weighted_var_y"] == pytest.approx(var_y_ref, rel=1e-6)
+    assert derived["weighted_var_x"] == pytest.approx(var_x_ref, rel=1e-6)
+    assert derived["weighted_cov_yx"] == pytest.approx(cov_yx_ref, rel=1e-6)
+
+
+def test_weighted_var_x_signals_horizontal_spread():
+    """Wider region should produce larger weighted_var_x than a narrower one."""
+    from skimage import measure
+    from octron.tools.export_tracking import _SPREAD_FROM_MOMENT
+
+    def _var_x_for(width):
+        H, W = 32, 96
+        mask = np.zeros((H, W), dtype=np.int8)
+        x_lo = (W - width) // 2
+        mask[8:24, x_lo : x_lo + width] = 1
+        intensity = np.zeros((H, W, 4), dtype=np.uint8)
+        # Uniform R intensity inside the mask
+        intensity[..., 0] = (mask.astype(np.int32) * 200).astype(np.uint8)
+        labeled = measure.label(mask, background=0, connectivity=2)
+        out = measure.regionprops_table(
+            labeled, intensity_image=intensity,
+            properties=["weighted_moments_central"],
+        )
+        m00 = out["weighted_moments_central-0-0-0"][0]
+        m02 = out["weighted_moments_central-0-2-0"][0]
+        return m02 / m00
+
+    narrow = _var_x_for(width=10)
+    wide   = _var_x_for(width=60)
+    assert wide > narrow
+
+
+def test_weighted_spread_columns_via_export(tmp_path):
+    """End-to-end: requesting weighted_var_y from the public export should
+    produce a numeric column populated from zarr masks + video pixels."""
+    import zarr
+    import cv2
+
+    pytest.importorskip("cv2")
+
+    csv_path = tmp_path / "animal_track_1.csv"
+    _write_prediction_csv(csv_path, track_id=1, n=3)
+    df = pd.read_csv(csv_path, skiprows=7)
+    n = len(df)
+
+    # Tiny zarr store with a centred square mask each frame.
+    store_path = tmp_path / "predictions.zarr"
+    store = zarr.storage.LocalStore(str(store_path))
+    root = zarr.open_group(store=store, mode="w")
+    H, W = 64, 64
+    masks = np.zeros((n, H, W), dtype=np.int8)
+    masks[:, 16:48, 16:48] = 1
+    arr = root.require_array("1_masks", shape=(n, H, W), dtype=np.int8)
+    arr[:] = masks
+
+    # Tiny matching video — uniform red so the R-channel weighted variance
+    # is finite and equal to the geometric variance of the mask.
+    video_path = tmp_path / "vid.mp4"
+    fourcc = cv2.VideoWriter_fourcc(*"mp4v")
+    writer = cv2.VideoWriter(str(video_path), fourcc, 5, (W, H))
+    if not writer.isOpened():
+        pytest.skip("cv2 VideoWriter unavailable in this environment")
+    frame = np.zeros((H, W, 3), dtype=np.uint8)
+    frame[..., 2] = 255  # BGR red
+    for _ in range(n):
+        writer.write(frame)
+    writer.release()
+
+    export_tracking(
+        tmp_path, output_dir=tmp_path,
+        region_properties=["weighted_var_y", "weighted_var_x", "weighted_cov_yx"],
+        video_path=video_path, overwrite=True,
+    )
+    out = pd.read_csv(csv_path, skiprows=7)
+    for col in ("weighted_var_y_r", "weighted_var_x_r", "weighted_cov_yx_r"):
+        assert col in out.columns, f"Missing derived column: {col}"
+        assert out[col].notna().all(), f"Column {col} has NaNs"
+    # Symmetric mask centred in the frame → cov_yx ≈ 0
+    assert abs(out["weighted_cov_yx_r"].iloc[0]) < 1e-6
+    # Square mask → var_y ≈ var_x
+    np.testing.assert_allclose(
+        out["weighted_var_y_r"].values, out["weighted_var_x_r"].values, atol=1e-6,
+    )
+
+
+def test_weighted_spread_in_intensity_props_set():
+    """Pseudo-props must be flagged intensity-requiring so they're skipped
+    when no video is provided (rather than silently producing NaN)."""
+    from octron.tools.export_tracking import _INTENSITY_PROPS, _WEIGHTED_SPREAD_PROPS
+    assert _WEIGHTED_SPREAD_PROPS <= _INTENSITY_PROPS
+
+
 def test_translation_variant_set_classification():
     """Defensive: shape props should NOT be in the variant set; the variant
     set must contain centroid and weighted_centroid."""

--- a/tests/test_export_tracking.py
+++ b/tests/test_export_tracking.py
@@ -11,7 +11,7 @@ column names (pos_x, pos_y, area, …) are kept — no renaming.
 
   pos_x / pos_y : scalar centroid per chosen method
   area          : largest segment's area ("largest") OR sum of all segments
-                  ("weighted" / "mask_com")
+                  ("weighted")
   orientation   : always from the largest segment (circular quantity)
   all other regionprops : resolved by chosen method
 
@@ -57,7 +57,6 @@ _export_tracking_from_data
     other regionprops resolved via chosen method
     combined=False → one file per track
     combined=True  → single all_tracks.csv
-    mask_com with zarr_root=None falls back gracefully
     header metadata preserved in output
 
 export_tracking (public)
@@ -440,13 +439,6 @@ def test_export_combined_contains_all_tracks(tmp_path):
     df = pd.read_csv(tmp_path / "all_tracks.csv", skiprows=7)
     assert set(df["track_id"].unique()) == {0, 1, 2}
 
-def test_export_mask_com_fallback_no_error(tmp_path):
-    _export_tracking_from_data(tmp_path, *_minimal_data(),
-                                method="mask_com", zarr_root=None, combined=False)
-    df = _read_output(tmp_path)
-    assert "pos_x" in df.columns
-    assert not df["pos_x"].isna().all()
-
 def test_export_header_preserved(tmp_path):
     _export_tracking_from_data(tmp_path, *_minimal_data(),
                                 method="largest", zarr_root=None, combined=False)
@@ -734,6 +726,64 @@ def test_raw_parquet_emits_warning(tmp_path, caplog):
     assert any("raw" in rec.message and "parquet" in rec.message
                for rec in caplog.records), \
         "Expected a warning mentioning raw + parquet"
+
+
+# ===========================================================================
+# compute_weighted_centroids
+# ===========================================================================
+
+def test_weighted_centroids_scalar_passthrough(tmp_path):
+    """Scalar pos_x/pos_y in the CSV passes through unchanged."""
+    from octron.tools.export_tracking import compute_weighted_centroids
+    _write_prediction_csv(tmp_path / "animal_track_1.csv", track_id=1, n=3)
+    out = compute_weighted_centroids(tmp_path)
+    assert 1 in out
+    # _write_prediction_csv writes pos_x = arange(n) and pos_y = arange(n)
+    assert out[1][0] == pytest.approx((0.0, 0.0))
+    assert out[1][2] == pytest.approx((2.0, 2.0))
+
+
+def test_weighted_centroids_multi_segment(tmp_path):
+    """Tuple-string rows resolve to area-weighted means."""
+    from octron.tools.export_tracking import compute_weighted_centroids
+    csv_path = tmp_path / "animal_track_1.csv"
+    _write_prediction_csv(csv_path, track_id=1, n=2)
+    df = pd.read_csv(csv_path, skiprows=7)
+    df["pos_x"] = df["pos_x"].astype(object)
+    df["pos_y"] = df["pos_y"].astype(object)
+    df["area"] = df["area"].astype(object)
+    # Frame 0: equal areas → mean is 50, frame 1: 3:1 weight on x=0
+    df.loc[0, "pos_x"] = _tup((0.0, 100.0))
+    df.loc[0, "pos_y"] = _tup((0.0, 100.0))
+    df.loc[0, "area"]  = _tup((50.0, 50.0))
+    df.loc[1, "pos_x"] = _tup((0.0, 100.0))
+    df.loc[1, "pos_y"] = _tup((0.0,   0.0))
+    df.loc[1, "area"]  = _tup((75.0, 25.0))
+    meta = _read_csv_metadata(csv_path)
+    with open(csv_path, "w") as f:
+        f.write(_build_header(meta))
+        df.to_csv(f, index=False, lineterminator="\n")
+
+    out = compute_weighted_centroids(tmp_path)
+    assert out[1][0] == pytest.approx((50.0, 50.0))
+    cx1, cy1 = out[1][1]
+    assert 0.0 < cx1 < 100.0   # weighted between segment positions
+    assert cy1 == pytest.approx(0.0)
+
+
+def test_weighted_centroids_track_id_filter(tmp_path):
+    """Only the requested track_ids appear in the result."""
+    from octron.tools.export_tracking import compute_weighted_centroids
+    _write_prediction_csv(tmp_path / "animal_track_1.csv", track_id=1)
+    _write_prediction_csv(tmp_path / "animal_track_2.csv", track_id=2)
+    out = compute_weighted_centroids(tmp_path, track_ids=[1])
+    assert set(out.keys()) == {1}
+
+
+def test_weighted_centroids_empty_dir(tmp_path):
+    """No CSVs → empty dict, no exception."""
+    from octron.tools.export_tracking import compute_weighted_centroids
+    assert compute_weighted_centroids(tmp_path) == {}
 
 
 # ===========================================================================

--- a/tests/test_export_tracking.py
+++ b/tests/test_export_tracking.py
@@ -621,6 +621,122 @@ def test_public_export_raises_on_missing_csvs(tmp_path):
 
 
 # ===========================================================================
+# _export_tracking_from_data — method="raw"
+# ===========================================================================
+
+def test_raw_single_segment_pos_passthrough(tmp_path):
+    """Scalar values pass through unchanged."""
+    tids, labels, fc, fi, conf, sx, sy, sa, bbox, rp, meta = _minimal_data(n=4)
+    _export_tracking_from_data(tmp_path, tids, labels, fc, fi, conf, sx, sy, sa,
+                                bbox, rp, meta, method="raw",
+                                zarr_root=None, combined=False)
+    df = _read_output(tmp_path)
+    np.testing.assert_allclose(df["pos_x"].astype(float).values, sx[0].astype(float))
+
+
+def test_raw_multi_segment_pos_x_keeps_tuple_string(tmp_path):
+    """Multi-segment rows keep their tuple-string verbatim."""
+    tids, labels, fc, fi, conf, sx, sy, sa, bbox, rp, meta = _minimal_data(n=1)
+    sx[0] = np.array([_tup((10.0, 90.0))], dtype=object)
+    sy[0] = np.array([_tup(( 5.0, 50.0))], dtype=object)
+    sa[0] = np.array([_tup((50.0, 300.0))], dtype=object)
+    _export_tracking_from_data(tmp_path, tids, labels, fc, fi, conf, sx, sy, sa,
+                                bbox, rp, meta, method="raw",
+                                zarr_root=None, combined=False)
+    df = _read_output(tmp_path)
+    assert df["pos_x"].iloc[0] == _tup((10.0, 90.0))
+    assert df["pos_y"].iloc[0] == _tup(( 5.0, 50.0))
+
+
+def test_raw_area_keeps_tuple_string(tmp_path):
+    """area is NOT summed in raw mode — tuple-string preserved."""
+    tids, labels, fc, fi, conf, sx, sy, sa, bbox, rp, meta = _minimal_data(n=1)
+    sa[0] = np.array([_tup((200.0, 50.0))], dtype=object)
+    sx[0] = np.array([_tup((0.0, 0.0))], dtype=object)
+    sy[0] = np.array([_tup((0.0, 0.0))], dtype=object)
+    _export_tracking_from_data(tmp_path, tids, labels, fc, fi, conf, sx, sy, sa,
+                                bbox, rp, meta, method="raw",
+                                zarr_root=None, combined=False)
+    df = _read_output(tmp_path)
+    assert df["area"].iloc[0] == _tup((200.0, 50.0))
+
+
+def test_raw_orientation_no_special_case(tmp_path):
+    """orientation is NOT forced to 'largest' in raw mode."""
+    tids, labels, fc, fi, conf, sx, sy, sa, bbox, rp, meta = _minimal_data(n=1)
+    sa[0] = np.array([_tup((50.0, 300.0))], dtype=object)
+    sx[0] = np.array([_tup((0.0, 0.0))], dtype=object)
+    sy[0] = np.array([_tup((0.0, 0.0))], dtype=object)
+    rp[0] = {"orientation": np.array([_tup((1.0, 2.0))], dtype=object)}
+    _export_tracking_from_data(tmp_path, tids, labels, fc, fi, conf, sx, sy, sa,
+                                bbox, rp, meta, method="raw",
+                                zarr_root=None, combined=False)
+    df = _read_output(tmp_path)
+    assert df["orientation"].iloc[0] == _tup((1.0, 2.0))
+
+
+def test_raw_regionprops_passthrough(tmp_path):
+    """Mixed scalar + tuple regionprops survive verbatim in raw mode."""
+    tids, labels, fc, fi, conf, sx, sy, sa, bbox, rp, meta = _minimal_data(n=2)
+    sa[0] = np.array([_tup((200.0, 50.0)), 100.0], dtype=object)
+    rp[0] = {"solidity": np.array([_tup((0.9, 0.4)), 0.8], dtype=object)}
+    _export_tracking_from_data(tmp_path, tids, labels, fc, fi, conf, sx, sy, sa,
+                                bbox, rp, meta, method="raw",
+                                zarr_root=None, combined=False)
+    df = _read_output(tmp_path)
+    assert df["solidity"].iloc[0] == _tup((0.9, 0.4))
+    assert float(df["solidity"].iloc[1]) == pytest.approx(0.8)
+
+
+def test_raw_is_default_method_for_public_api(tmp_path):
+    """export_tracking() with no method= argument should preserve tuple-strings."""
+    csv_path = tmp_path / "animal_track_1.csv"
+    _write_prediction_csv(csv_path, track_id=1, n=2)
+    df = pd.read_csv(csv_path, skiprows=7)
+    df["pos_x"] = df["pos_x"].astype(object)
+    df["area"] = df["area"].astype(object)
+    df.loc[0, "pos_x"] = _tup((10.0, 90.0))
+    df.loc[0, "area"] = _tup((50.0, 300.0))
+    meta = _read_csv_metadata(csv_path)
+    from octron.tools.export_tracking import _build_header
+    with open(csv_path, "w") as f:
+        f.write(_build_header(meta))
+        df.to_csv(f, index=False, lineterminator="\n")
+
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+    export_tracking(tmp_path, output_dir=out_dir)  # no method= → defaults to raw
+    out = pd.read_csv(out_dir / "animal_track_1.csv", skiprows=7)
+    assert out["pos_x"].iloc[0] == _tup((10.0, 90.0))
+    assert out["area"].iloc[0] == _tup((50.0, 300.0))
+
+
+def test_raw_parquet_emits_warning(tmp_path, caplog):
+    """method='raw' + fmt='parquet' should warn about string-typed columns."""
+    pytest.importorskip("pyarrow")
+    import logging
+    from loguru import logger as _logger
+
+    # Loguru → stdlib logging bridge so caplog captures the warning
+    class _PropagateHandler(logging.Handler):
+        def emit(self, record):
+            logging.getLogger(record.name).handle(record)
+
+    handler_id = _logger.add(_PropagateHandler(), format="{message}", level="WARNING")
+    try:
+        with caplog.at_level("WARNING"):
+            _export_tracking_from_data(tmp_path, *_minimal_data(),
+                                        method="raw", zarr_root=None,
+                                        combined=False, fmt="parquet")
+    finally:
+        _logger.remove(handler_id)
+
+    assert any("raw" in rec.message and "parquet" in rec.message
+               for rec in caplog.records), \
+        "Expected a warning mentioning raw + parquet"
+
+
+# ===========================================================================
 # export_tracking — overwrite guard
 # ===========================================================================
 

--- a/tests/test_export_tracking.py
+++ b/tests/test_export_tracking.py
@@ -1113,6 +1113,62 @@ def test_weighted_spread_in_intensity_props_set():
     assert _WEIGHTED_SPREAD_PROPS <= _INTENSITY_PROPS
 
 
+def test_video_shorter_than_zarr_does_not_crash(tmp_path, caplog):
+    """Regression: when the video file is shorter than the zarr's frame count,
+    cv2.read() returns ok=False for frames past EOF.  The worker must skip
+    those frames (rather than feed intensity_image=None into a regionprops_table
+    that requested intensity_max — which raises AttributeError mid-export and
+    blows away hours of compute).  The completed frames must still land in the
+    output."""
+    import zarr
+    import cv2
+
+    pytest.importorskip("cv2")
+
+    csv_path = tmp_path / "animal_track_1.csv"
+    _write_prediction_csv(csv_path, track_id=1, n=5)
+    df = pd.read_csv(csv_path, skiprows=7)
+    n = len(df)  # 5 frames in the CSV
+
+    store_path = tmp_path / "predictions.zarr"
+    store = zarr.storage.LocalStore(str(store_path))
+    root = zarr.open_group(store=store, mode="w")
+    H, W = 64, 64
+    masks = np.zeros((n, H, W), dtype=np.int8)
+    masks[:, 16:48, 16:48] = 1
+    arr = root.require_array("1_masks", shape=(n, H, W), dtype=np.int8)
+    arr[:] = masks
+
+    # Video with FEWER frames than the zarr — emulates the real-world
+    # zarr/video mismatch that crashed the third sleep-segmentation export.
+    video_path = tmp_path / "vid.mp4"
+    fourcc = cv2.VideoWriter_fourcc(*"mp4v")
+    writer = cv2.VideoWriter(str(video_path), fourcc, 5, (W, H))
+    if not writer.isOpened():
+        pytest.skip("cv2 VideoWriter unavailable in this environment")
+    frame = np.zeros((H, W, 3), dtype=np.uint8)
+    frame[..., 2] = 255  # BGR red
+    for _ in range(2):  # only 2 frames written, vs zarr's 5
+        writer.write(frame)
+    writer.release()
+
+    # If the regression returns, this call raises AttributeError mid-export.
+    export_tracking(
+        tmp_path, output_dir=tmp_path,
+        region_properties=["intensity_mean", "intensity_max"],
+        video_path=video_path, overwrite=True,
+    )
+
+    out = pd.read_csv(csv_path, skiprows=7)
+    # The first ~2 frames have intensity computed; later frames are NaN.
+    # Either is fine — the contract is "no crash + at least the early
+    # frames have values".
+    assert "intensity_mean_r" in out.columns
+    assert out["intensity_mean_r"].notna().any(), (
+        "Expected at least one frame with computed intensity_mean_r."
+    )
+
+
 def test_translation_variant_set_classification():
     """Defensive: shape props should NOT be in the variant set; the variant
     set must contain centroid and weighted_centroid."""


### PR DESCRIPTION
## Summary

Adds a fully standalone `octron export` command (and `export_tracking()` Python API) that post-processes prediction outputs into clean, analysis-ready files — without needing to re-run prediction.

### Core export pipeline
- Reads per-track CSVs from any `octron_predictions/` directory
- Three strategies for handling multi-segment frames (where an animal briefly splits into disconnected blobs):
  - **`--method raw`** *(default)*: tuple-strings pass through unchanged — matches the original `predict` output, no info loss. Single-segment rows stay scalar.
  - **`--method largest`**: use values from the single largest segment per frame. Fully numeric output.
  - **`--method weighted`**: area-weighted mean across all segments. Fully numeric. `area` becomes the *sum* of segment areas.
- `area` and `orientation` are special-cased under `largest`/`weighted` (orientation always uses largest — circular quantity)
- Atomic writes via temp file + `os.replace()` so an interrupted export never corrupts existing data
- `predict_batch` now writes its CSVs through the same export path with `method="raw"`, restoring `main`'s tuple-preserving output (was being collapsed to scalar in earlier branch revisions)

### Region properties
- Compute shape properties (`area_convex`, `eccentricity`, `solidity`, `moments_hu`, etc.) directly from zarr masks at export time — no need to have run `--detailed` during prediction
- `--region-properties` accepts `none`, `all`, `shape`, `intensity`, or a comma-separated list; `--list-properties` prints all available names
- Intensity properties (`intensity_mean`, `intensity_max`, `intensity_min`, `intensity_std`) computed from the original video when `--video` is provided (auto-detected if alongside the predictions directory); each property expands to four columns per channel: `_r`, `_g`, `_b`, `_lum`
- Canonical column order enforced on output: base cols → bbox → shape props (with multi-value expansions grouped) → intensity props

### Render integration
- Render now applies area-weighted centroids unconditionally — re-reads raw `pos_x`/`pos_y`/`area` tuple-strings from the CSV and resolves them via the same `_resolve_xy_weighted` helper. Fixes a latent issue where `get_tracking_data()`'s arithmetic-mean tuple resolution under-weighted large segments.
- `--tracklet-mask-centroids` flag and the underlying `compute_mask_centroids` zarr-CoM path are removed: simulations confirmed `mask_com` is algebraically equivalent to `weighted` (`Σ(Nᵢ·cxᵢ) ≡ Σ(x over foreground)`) but expensive (zarr I/O) and *less* accurate at the production 4× downsample default (~4 px RMS error).
- `yolo_results.py` is left untouched — the override happens in `render` before any rendering, so other consumers are unaffected.

### Performance
- `ProcessPoolExecutor` (spawn) for true CPU-parallel zarr regionprops computation across 8 workers
- Bounding-box crop before `label()`/`regionprops_table()` reduces array size per frame
- `np.where` replaced with `any(axis)+argmax` for bounding box detection (~4× faster)
- Network filesystem safe: `glob` + direct `.exists()` instead of recursive `rglob`
- `--debug` flag adds millisecond timestamps and per-step timing including per-batch sub-timers (`zarr_read`, `binary`, `bbox`, `label`, `props_table`)

### Output formats
- `--format csv` (default) or `--format parquet` (requires `pyarrow`, added as dependency)
- Parquet combined output writes each track as a separate row group for better compression and selective reads
- Video metadata stored in parquet schema; `--combined` writes a single `all_tracks.<ext>`
- `--overwrite` flag; overwrite guard checks the correct extension per format
- Warning emitted when `--method raw --format parquet` are combined (mixed-type columns get stringified, losing numeric typing on disk)

### UX
- `tqdm` progress bars at every level: per-track, per-prop resolution, per-chunk CSV writing
- `--list-properties` eager flag prints all available regionprop names grouped by category and exits

## Test plan
- [ ] Run `octron export <predictions_path>` on a real dataset and verify output CSVs
- [ ] Verify default `--method raw` preserves tuple-strings for multi-segment frames
- [ ] Test `--method largest` and `--method weighted` produce fully numeric output
- [ ] Test `--format parquet` and verify columns/metadata with `pd.read_parquet()`
- [ ] Test `--region-properties shape` and `--region-properties intensity --video <path>`
- [ ] Verify `--overwrite` guard raises on existing files, and passes with flag
- [ ] Run `octron render --tracklets` on a multi-segment dataset and confirm centroids look correct (no mask-CoM flag needed)
- [ ] Run test suite: `pytest tests/test_export_tracking.py` (61 tests covering raw/largest/weighted resolvers, region-property paths, parquet warning, weighted-centroid helper, and overwrite guards)

🤖 Generated with [Claude Code](https://claude.com/claude-code)