### PR TITLE
fix: show the napari logo on OCTRON's Windows taskbar button

### DIFF
--- a/octron/_taskbar.py
+++ b/octron/_taskbar.py
@@ -1,0 +1,166 @@
+"""Windows taskbar identity/icon helpers for OCTRON's main GUI window.
+
+Pure ``ctypes`` / Win32 — no Qt, torch, or napari imports — so this module is
+cheap to import and unit-testable (see ``tests/test_taskbar.py``). Everything is
+a no-op on non-Windows platforms.
+
+Why this exists
+---------------
+napari's OpenGL main window does not reliably surface its Qt window icon to the
+Windows taskbar, and it shares the process-wide AppUserModelID with Qt/vispy's
+hidden helper windows, so Windows collapses them into a single taskbar group
+with a generic icon. To get napari's logo on its own taskbar button we, on the
+window's shell property store, give it a per-window ``AppUserModelID`` (its own
+taskbar group) plus a ``RelaunchIconResource`` pointing at a real ``.ico``, and
+additionally force the native window icon via ``WM_SETICON``. All three are
+needed together — dropping any one falls back to a generic icon.
+"""
+
+import ctypes
+import os
+from ctypes import (POINTER, Structure, byref, c_byte, c_int, c_ulong, c_ushort,
+                    c_void_p, c_wchar_p, wintypes)
+
+# ctypes Structures are safe to define on any platform; only ``ctypes.windll``
+# and ``ctypes.WINFUNCTYPE`` are Windows-only, and those are referenced solely
+# inside the function bodies below (guarded by an ``os.name == "nt"`` check).
+
+
+class _GUID(Structure):
+    _fields_ = [("Data1", c_ulong), ("Data2", c_ushort),
+                ("Data3", c_ushort), ("Data4", c_byte * 8)]
+
+
+class _PROPERTYKEY(Structure):
+    _fields_ = [("fmtid", _GUID), ("pid", wintypes.DWORD)]
+
+
+class _PROPVARIANT(Structure):
+    # x64 layout: 8-byte header then the value union (we use the LPWSTR pointer).
+    _fields_ = [("vt", c_ushort), ("r1", c_ushort), ("r2", c_ushort),
+                ("r3", c_ushort), ("p", c_void_p), ("pad", c_byte * 8)]
+
+
+_VT_LPWSTR = 31
+_IID_IPropertyStore = "{886D8EEB-8CF2-4446-8D02-CDBA1DBDCF99}"
+_FMTID_AppUserModel = "{9F4C2855-9F79-4B39-A8D0-E1D42DE1D5F3}"
+_PID_APP_ID = 5          # PKEY_AppUserModel_ID
+_PID_RELAUNCH_ICON = 3   # PKEY_AppUserModel_RelaunchIconResource
+
+# IPropertyStore vtable slots.
+_SLOT_RELEASE = 2
+_SLOT_GETVALUE = 5
+_SLOT_SETVALUE = 6
+_SLOT_COMMIT = 7
+
+
+def _guid(s):
+    g = _GUID()
+    if ctypes.windll.ole32.IIDFromString(c_wchar_p(s), byref(g)) != 0:
+        raise OSError(f"IIDFromString({s}) failed")
+    return g
+
+
+def _vtable(store):
+    return ctypes.cast(ctypes.cast(store, POINTER(c_void_p))[0], POINTER(c_void_p))
+
+
+def _method(store, slot, restype, *argtypes):
+    return ctypes.WINFUNCTYPE(restype, c_void_p, *argtypes)(_vtable(store)[slot])
+
+
+def _open_property_store(hwnd):
+    store = c_void_p()
+    iid = _guid(_IID_IPropertyStore)
+    hr = ctypes.windll.shell32.SHGetPropertyStoreForWindow(
+        wintypes.HWND(hwnd), byref(iid), byref(store))
+    return store if hr == 0 else None
+
+
+def set_windows_taskbar_app_id(qt_window, app_id, icon_ico_path=None):
+    """Give a Qt window its own Windows taskbar identity and icon.
+
+    Sets a per-window ``AppUserModelID`` (own taskbar group), and when
+    ``icon_ico_path`` is given a ``RelaunchIconResource`` plus a forced native
+    icon (``WM_SETICON``) loaded from that ``.ico``.
+
+    No-op on non-Windows. Every failure (missing API, COM error, a window with
+    no native handle) is swallowed: the taskbar icon is cosmetic and must never
+    break GUI startup.
+    """
+    if os.name != "nt":
+        return
+    try:
+        hwnd = int(qt_window.winId())
+        ole32 = ctypes.windll.ole32
+        ole32.CoTaskMemAlloc.restype = c_void_p
+        fmtid = _guid(_FMTID_AppUserModel)
+
+        store = _open_property_store(hwnd)
+        if store is not None:
+            try:
+                set_value = _method(store, _SLOT_SETVALUE, c_int,
+                                    POINTER(_PROPERTYKEY), POINTER(_PROPVARIANT))
+                commit = _method(store, _SLOT_COMMIT, c_int)
+
+                def _set_str(pid, value):
+                    nbytes = (len(value) + 1) * 2
+                    mem = ole32.CoTaskMemAlloc(nbytes)
+                    ctypes.memmove(mem, ctypes.create_unicode_buffer(value), nbytes)
+                    pv = _PROPVARIANT()
+                    pv.vt = _VT_LPWSTR
+                    pv.p = mem
+                    set_value(store, byref(_PROPERTYKEY(fmtid, pid)), byref(pv))
+                    ole32.PropVariantClear(byref(pv))
+
+                _set_str(_PID_APP_ID, app_id)
+                if icon_ico_path:
+                    _set_str(_PID_RELAUNCH_ICON, f"{icon_ico_path},0")
+                commit(store)
+            finally:
+                _method(store, _SLOT_RELEASE, c_int)(store)
+
+        # Force the native window icon from the .ico — the napari window does not
+        # surface its Qt icon to the taskbar reliably on its own.
+        if icon_ico_path and os.path.exists(icon_ico_path):
+            user32 = ctypes.windll.user32
+            user32.LoadImageW.restype = c_void_p
+            image_icon, lr_loadfromfile = 1, 0x10
+            wm_seticon, icon_small, icon_big = 0x80, 0, 1
+            for size, which in ((32, icon_big), (16, icon_small)):
+                hicon = user32.LoadImageW(None, c_wchar_p(icon_ico_path),
+                                          image_icon, size, size, lr_loadfromfile)
+                if hicon:
+                    user32.SendMessageW(wintypes.HWND(hwnd), wm_seticon,
+                                        which, c_void_p(hicon))
+    except Exception:
+        pass
+
+
+def get_windows_taskbar_app_id(qt_window):
+    """Return the per-window ``AppUserModelID`` set on a Qt window, or ``None``.
+
+    Companion to :func:`set_windows_taskbar_app_id` used to verify it in tests.
+    Returns ``None`` on non-Windows, on failure, or when no per-window id is set.
+    """
+    if os.name != "nt":
+        return None
+    try:
+        hwnd = int(qt_window.winId())
+        store = _open_property_store(hwnd)
+        if store is None:
+            return None
+        try:
+            get_value = _method(store, _SLOT_GETVALUE, c_int,
+                                POINTER(_PROPERTYKEY), POINTER(_PROPVARIANT))
+            key = _PROPERTYKEY(_guid(_FMTID_AppUserModel), _PID_APP_ID)
+            pv = _PROPVARIANT()
+            if get_value(store, byref(key), byref(pv)) != 0:
+                return None
+            value = ctypes.wstring_at(pv.p) if pv.p else None
+            ctypes.windll.ole32.PropVariantClear(byref(pv))
+            return value
+        finally:
+            _method(store, _SLOT_RELEASE, c_int)(store)
+    except Exception:
+        return None

--- a/octron/main.py
+++ b/octron/main.py
@@ -1993,116 +1993,16 @@ def octron_gui():
     # Give the napari window its own Windows taskbar group (id distinct from the
     # process-wide one above) while it is still hidden, so when it is shown the
     # taskbar button is created in a group of its own and displays napari's logo
-    # instead of a generic shared-group icon. We also point the taskbar straight
-    # at napari's bundled .ico, because the napari OpenGL window does not reliably
-    # surface its Qt window icon to the taskbar on its own.
+    # instead of a generic shared-group icon. The .ico is napari's, because the
+    # napari OpenGL window does not reliably surface its Qt window icon to the
+    # taskbar on its own. See octron/_taskbar.py and tests/test_taskbar.py.
+    from octron._taskbar import set_windows_taskbar_app_id
     _napari_ico = os.path.join(os.path.dirname(napari.__file__), "resources", "icon.ico")
-    _set_windows_taskbar_app_id(
+    set_windows_taskbar_app_id(
         viewer.window._qt_window, "OCTRON-tracking.OCTRON.viewer", _napari_ico)
 
     viewer.window.show()
     napari.run()
-
-
-def _set_windows_taskbar_app_id(qt_window, app_id, icon_ico_path=None):
-    """Pin a Qt window's Windows taskbar identity and icon (Windows only).
-
-    Sets, on the window's shell property store, a per-window AppUserModelID (so
-    the window gets its own taskbar group instead of a generic shared one) and,
-    if ``icon_ico_path`` is given, a RelaunchIconResource pointing at that .ico
-    (so the taskbar draws that icon explicitly). It also force-sets the window's
-    native icon via WM_SETICON, because the napari OpenGL window does not
-    reliably surface its Qt window icon to the taskbar on its own.
-
-    Every failure (non-Windows, missing APIs, COM error) is swallowed: the
-    taskbar icon is cosmetic and must never break GUI startup.
-    """
-    import os
-
-    if os.name != "nt":
-        return
-    try:
-        import ctypes
-        from ctypes import (POINTER, Structure, byref, c_byte, c_int, c_ulong,
-                            c_ushort, c_void_p, c_wchar_p, wintypes)
-
-        class GUID(Structure):
-            _fields_ = [("Data1", c_ulong), ("Data2", c_ushort),
-                        ("Data3", c_ushort), ("Data4", c_byte * 8)]
-
-        class PROPERTYKEY(Structure):
-            _fields_ = [("fmtid", GUID), ("pid", wintypes.DWORD)]
-
-        class PROPVARIANT(Structure):
-            # x64 layout: 8-byte header then the value union (LPWSTR pointer).
-            _fields_ = [("vt", c_ushort), ("r1", c_ushort), ("r2", c_ushort),
-                        ("r3", c_ushort), ("p", c_void_p), ("pad", c_byte * 8)]
-
-        VT_LPWSTR = 31
-        ole32 = ctypes.windll.ole32
-        shell32 = ctypes.windll.shell32
-        user32 = ctypes.windll.user32
-
-        def _guid(s):
-            g = GUID()
-            if ole32.IIDFromString(c_wchar_p(s), byref(g)) != 0:
-                raise OSError("IIDFromString failed")
-            return g
-
-        # PKEY_AppUserModel_ID (pid 5) and ...RelaunchIconResource (pid 3) share
-        # one fmtid.
-        appmodel_fmtid = _guid("{9F4C2855-9F79-4B39-A8D0-E1D42DE1D5F3}")
-        iid_property_store = _guid("{886D8EEB-8CF2-4446-8D02-CDBA1DBDCF99}")
-
-        hwnd = int(qt_window.winId())
-
-        # 1) Per-window AppUserModelID + RelaunchIconResource via property store.
-        store = c_void_p()
-        if shell32.SHGetPropertyStoreForWindow(
-                wintypes.HWND(hwnd), byref(iid_property_store), byref(store)) == 0:
-            try:
-                funcs = ctypes.cast(
-                    ctypes.cast(store, POINTER(c_void_p))[0], POINTER(c_void_p))
-                SetValue = ctypes.WINFUNCTYPE(
-                    c_int, c_void_p, POINTER(PROPERTYKEY), POINTER(PROPVARIANT))(funcs[6])
-                Commit = ctypes.WINFUNCTYPE(c_int, c_void_p)(funcs[7])
-                ole32.CoTaskMemAlloc.restype = c_void_p
-
-                def _set_str(pid, value):
-                    nbytes = (len(value) + 1) * 2
-                    mem = ole32.CoTaskMemAlloc(nbytes)
-                    ctypes.memmove(mem, ctypes.create_unicode_buffer(value), nbytes)
-                    pv = PROPVARIANT()
-                    pv.vt = VT_LPWSTR
-                    pv.p = mem
-                    SetValue(store, byref(PROPERTYKEY(appmodel_fmtid, pid)), byref(pv))
-                    ole32.PropVariantClear(byref(pv))
-
-                _set_str(5, app_id)
-                if icon_ico_path:
-                    _set_str(3, f"{icon_ico_path},0")
-                Commit(store)
-            finally:
-                ctypes.WINFUNCTYPE(c_int, c_void_p)(
-                    ctypes.cast(ctypes.cast(store, POINTER(c_void_p))[0],
-                                POINTER(c_void_p))[2])(store)
-
-        # 2) Force the native window icon from the .ico (WM_SETICON), since the
-        # napari window's Qt icon does not reach the taskbar reliably.
-        if icon_ico_path and os.path.exists(icon_ico_path):
-            IMAGE_ICON, LR_LOADFROMFILE = 1, 0x10
-            WM_SETICON, ICON_SMALL, ICON_BIG = 0x80, 0, 1
-            user32.LoadImageW.restype = c_void_p
-            big = user32.LoadImageW(None, c_wchar_p(icon_ico_path), IMAGE_ICON,
-                                    32, 32, LR_LOADFROMFILE)
-            small = user32.LoadImageW(None, c_wchar_p(icon_ico_path), IMAGE_ICON,
-                                      16, 16, LR_LOADFROMFILE)
-            if big:
-                user32.SendMessageW(wintypes.HWND(hwnd), WM_SETICON, ICON_BIG, c_void_p(big))
-            if small:
-                user32.SendMessageW(wintypes.HWND(hwnd), WM_SETICON, ICON_SMALL, c_void_p(small))
-    except Exception:
-        pass
 
 
 if __name__ == "__main__":

--- a/octron/main.py
+++ b/octron/main.py
@@ -1961,21 +1961,148 @@ def octron_gui():
     #      octron-gui = "octron.main:octron_gui"
 
     """
+    import os, sys
+
+    # Process-wide AppUserModelID before the QApplication exists. Qt/vispy's
+    # hidden helper windows inherit this; the visible napari window gets its own
+    # (distinct) id below so it does not share a taskbar group with them.
+    if os.name == "nt" and not getattr(sys, "frozen", False):
+        import ctypes
+        ctypes.windll.shell32.SetCurrentProcessExplicitAppUserModelID("OCTRON-tracking.OCTRON")
+
     from octron._logging import setup_logging
     setup_logging()
 
-    viewer = napari.Viewer()
-    
-    # If there's already a QApplication instance (as may be the case when running as a napari plugin),
-    # then set its style explicitly:
-    app = QApplication.instance()
-    if app is not None:
-        # This is a hack to get the style to look similar on darwin and windows systems
-        # for the ToolBox widget
-        app.setStyle(QStyleFactory.create("Fusion")) 
-    
+    # Create the QApplication ourselves so napari's get_app() reuses it.
+    app = QApplication.instance() or QApplication(sys.argv)
+
+    # Apply the Fusion style (a hack to make the ToolBox widget look consistent
+    # across macOS and Windows) *before* any window is created. Changing the
+    # application style after a window has been shown re-polishes/recreates it
+    # and, on Windows, destroys its taskbar identity so the taskbar button falls
+    # back to a generic icon. Setting it up front avoids that entirely.
+    app.setStyle(QStyleFactory.create("Fusion"))
+
+    # Build the viewer *hidden* so we can set the window's own taskbar identity
+    # before it is ever shown. Windows creates a window's taskbar button the first
+    # time it is shown and binds the button's AppUserModelID at that moment;
+    # changing the id afterwards does not reliably re-group an existing button.
+    viewer = napari.Viewer(show=False)
     viewer.window.add_dock_widget(octron_widget(viewer))
+
+    # Give the napari window its own Windows taskbar group (id distinct from the
+    # process-wide one above) while it is still hidden, so when it is shown the
+    # taskbar button is created in a group of its own and displays napari's logo
+    # instead of a generic shared-group icon. We also point the taskbar straight
+    # at napari's bundled .ico, because the napari OpenGL window does not reliably
+    # surface its Qt window icon to the taskbar on its own.
+    _napari_ico = os.path.join(os.path.dirname(napari.__file__), "resources", "icon.ico")
+    _set_windows_taskbar_app_id(
+        viewer.window._qt_window, "OCTRON-tracking.OCTRON.viewer", _napari_ico)
+
+    viewer.window.show()
     napari.run()
+
+
+def _set_windows_taskbar_app_id(qt_window, app_id, icon_ico_path=None):
+    """Pin a Qt window's Windows taskbar identity and icon (Windows only).
+
+    Sets, on the window's shell property store, a per-window AppUserModelID (so
+    the window gets its own taskbar group instead of a generic shared one) and,
+    if ``icon_ico_path`` is given, a RelaunchIconResource pointing at that .ico
+    (so the taskbar draws that icon explicitly). It also force-sets the window's
+    native icon via WM_SETICON, because the napari OpenGL window does not
+    reliably surface its Qt window icon to the taskbar on its own.
+
+    Every failure (non-Windows, missing APIs, COM error) is swallowed: the
+    taskbar icon is cosmetic and must never break GUI startup.
+    """
+    import os
+
+    if os.name != "nt":
+        return
+    try:
+        import ctypes
+        from ctypes import (POINTER, Structure, byref, c_byte, c_int, c_ulong,
+                            c_ushort, c_void_p, c_wchar_p, wintypes)
+
+        class GUID(Structure):
+            _fields_ = [("Data1", c_ulong), ("Data2", c_ushort),
+                        ("Data3", c_ushort), ("Data4", c_byte * 8)]
+
+        class PROPERTYKEY(Structure):
+            _fields_ = [("fmtid", GUID), ("pid", wintypes.DWORD)]
+
+        class PROPVARIANT(Structure):
+            # x64 layout: 8-byte header then the value union (LPWSTR pointer).
+            _fields_ = [("vt", c_ushort), ("r1", c_ushort), ("r2", c_ushort),
+                        ("r3", c_ushort), ("p", c_void_p), ("pad", c_byte * 8)]
+
+        VT_LPWSTR = 31
+        ole32 = ctypes.windll.ole32
+        shell32 = ctypes.windll.shell32
+        user32 = ctypes.windll.user32
+
+        def _guid(s):
+            g = GUID()
+            if ole32.IIDFromString(c_wchar_p(s), byref(g)) != 0:
+                raise OSError("IIDFromString failed")
+            return g
+
+        # PKEY_AppUserModel_ID (pid 5) and ...RelaunchIconResource (pid 3) share
+        # one fmtid.
+        appmodel_fmtid = _guid("{9F4C2855-9F79-4B39-A8D0-E1D42DE1D5F3}")
+        iid_property_store = _guid("{886D8EEB-8CF2-4446-8D02-CDBA1DBDCF99}")
+
+        hwnd = int(qt_window.winId())
+
+        # 1) Per-window AppUserModelID + RelaunchIconResource via property store.
+        store = c_void_p()
+        if shell32.SHGetPropertyStoreForWindow(
+                wintypes.HWND(hwnd), byref(iid_property_store), byref(store)) == 0:
+            try:
+                funcs = ctypes.cast(
+                    ctypes.cast(store, POINTER(c_void_p))[0], POINTER(c_void_p))
+                SetValue = ctypes.WINFUNCTYPE(
+                    c_int, c_void_p, POINTER(PROPERTYKEY), POINTER(PROPVARIANT))(funcs[6])
+                Commit = ctypes.WINFUNCTYPE(c_int, c_void_p)(funcs[7])
+                ole32.CoTaskMemAlloc.restype = c_void_p
+
+                def _set_str(pid, value):
+                    nbytes = (len(value) + 1) * 2
+                    mem = ole32.CoTaskMemAlloc(nbytes)
+                    ctypes.memmove(mem, ctypes.create_unicode_buffer(value), nbytes)
+                    pv = PROPVARIANT()
+                    pv.vt = VT_LPWSTR
+                    pv.p = mem
+                    SetValue(store, byref(PROPERTYKEY(appmodel_fmtid, pid)), byref(pv))
+                    ole32.PropVariantClear(byref(pv))
+
+                _set_str(5, app_id)
+                if icon_ico_path:
+                    _set_str(3, f"{icon_ico_path},0")
+                Commit(store)
+            finally:
+                ctypes.WINFUNCTYPE(c_int, c_void_p)(
+                    ctypes.cast(ctypes.cast(store, POINTER(c_void_p))[0],
+                                POINTER(c_void_p))[2])(store)
+
+        # 2) Force the native window icon from the .ico (WM_SETICON), since the
+        # napari window's Qt icon does not reach the taskbar reliably.
+        if icon_ico_path and os.path.exists(icon_ico_path):
+            IMAGE_ICON, LR_LOADFROMFILE = 1, 0x10
+            WM_SETICON, ICON_SMALL, ICON_BIG = 0x80, 0, 1
+            user32.LoadImageW.restype = c_void_p
+            big = user32.LoadImageW(None, c_wchar_p(icon_ico_path), IMAGE_ICON,
+                                    32, 32, LR_LOADFROMFILE)
+            small = user32.LoadImageW(None, c_wchar_p(icon_ico_path), IMAGE_ICON,
+                                      16, 16, LR_LOADFROMFILE)
+            if big:
+                user32.SendMessageW(wintypes.HWND(hwnd), WM_SETICON, ICON_BIG, c_void_p(big))
+            if small:
+                user32.SendMessageW(wintypes.HWND(hwnd), WM_SETICON, ICON_SMALL, c_void_p(small))
+    except Exception:
+        pass
 
 
 if __name__ == "__main__":

--- a/tests/test_taskbar.py
+++ b/tests/test_taskbar.py
@@ -1,0 +1,142 @@
+"""Tests for the Windows taskbar identity/icon helper (octron/_taskbar.py).
+
+These guard the fix that gives OCTRON's napari window its own taskbar button
+with napari's logo (branch fix/windows-taskbar-icon). They are deliberately
+lightweight: the pure-ctypes helper is imported directly (no torch/napari), and
+the Windows-only round-trip creates a bare QApplication rather than launching
+the GUI.
+
+What is and isn't covered
+-------------------------
+- COM correctness: the per-window AppUserModelID we write can be read back
+  (catches a broken PROPVARIANT layout, wrong vtable slot, or bad GUID).
+- The "must never break GUI startup" contract: the setter swallows all errors.
+- A source-level guard that octron_gui() applies the Qt style BEFORE creating
+  the window (the regression that caused the bug — setStyle after the window is
+  shown wipes its taskbar identity).
+- NOT covered: that the taskbar actually *renders* napari's logo. That is a
+  Windows shell behaviour with no headless API to assert; it is verified
+  manually.
+"""
+
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+import octron
+from octron._taskbar import (get_windows_taskbar_app_id,
+                             set_windows_taskbar_app_id)
+
+WINDOWS = os.name == "nt"
+
+
+class _ExplodingWindow:
+    """A stand-in Qt window whose winId() raises, to prove errors are swallowed."""
+
+    def winId(self):
+        raise RuntimeError("winId boom")
+
+
+def test_setter_never_raises_on_bad_window():
+    # Taskbar icon is cosmetic: a broken window object must not crash startup.
+    set_windows_taskbar_app_id(_ExplodingWindow(), "OCTRON.Test")
+
+
+def test_setter_never_raises_with_missing_icon(tmp_path):
+    missing = tmp_path / "does-not-exist.ico"
+    set_windows_taskbar_app_id(_ExplodingWindow(), "OCTRON.Test", str(missing))
+
+
+def test_getter_never_raises_on_bad_window():
+    assert get_windows_taskbar_app_id(_ExplodingWindow()) is None
+
+
+@pytest.mark.skipif(WINDOWS, reason="non-Windows no-op behaviour")
+def test_noop_off_windows():
+    # Off Windows the helpers return immediately without ever touching the window.
+    class _NeverCalled:
+        def winId(self):
+            raise AssertionError("winId must not be called off Windows")
+
+    set_windows_taskbar_app_id(_NeverCalled(), "OCTRON.Test")
+    assert get_windows_taskbar_app_id(_NeverCalled()) is None
+
+
+# The COM round-trip needs a real Qt application window (the shell property
+# store does not work on a bare native window), but a QApplication hangs pytest
+# at teardown. So we run it in an isolated subprocess that force-exits — the same
+# isolation strategy tests/test_cli.py uses for fragile GUI imports.
+_ROUNDTRIP_SUBPROCESS = textwrap.dedent(
+    """
+    import ctypes, os, sys
+    from ctypes import wintypes
+    from qtpy.QtWidgets import QApplication, QMainWindow
+    from octron._taskbar import (set_windows_taskbar_app_id,
+                                 get_windows_taskbar_app_id)
+
+    ico = sys.argv[1]
+    app = QApplication.instance() or QApplication([])  # must be kept alive
+    win = QMainWindow()
+    hwnd = wintypes.HWND(int(win.winId()))
+    set_windows_taskbar_app_id(win, "OCTRON.Test.RoundTrip", ico)
+    print("APPID:", get_windows_taskbar_app_id(win))
+    WM_GETICON, ICON_BIG = 0x7F, 1
+    print("ICONBIG_NONZERO:", bool(
+        ctypes.windll.user32.SendMessageW(hwnd, WM_GETICON, ICON_BIG, 0)))
+    sys.stdout.flush()
+    os._exit(0)  # skip Qt teardown, which can hang the process
+    """
+)
+
+
+@pytest.mark.skipif(not WINDOWS, reason="Windows-only shell property store")
+def test_app_id_and_icon_roundtrip_on_windows(tmp_path):
+    """The AppUserModelID we set reads back, and the .ico becomes the window icon.
+
+    Exercises the real COM plumbing end to end: a wrong PROPVARIANT layout,
+    vtable slot, or GUID would make the read-back wrong/None, and a broken
+    WM_SETICON path would leave ICON_BIG null.
+    """
+    pytest.importorskip("qtpy")
+    Image = pytest.importorskip("PIL.Image")
+
+    ico = tmp_path / "tiny.ico"
+    Image.new("RGBA", (32, 32), (255, 0, 255, 255)).save(ico, format="ICO")
+
+    result = subprocess.run(
+        [sys.executable, "-c", _ROUNDTRIP_SUBPROCESS, str(ico)],
+        capture_output=True, text=True, timeout=120,
+    )
+    output = result.stdout + result.stderr
+    assert "APPID: OCTRON.Test.RoundTrip" in output, output
+    assert "ICONBIG_NONZERO: True" in output, output
+
+
+def test_octron_gui_applies_style_before_creating_window():
+    """Source-level guard for the root-cause regression.
+
+    Changing the Qt application style after a window is shown wipes that window's
+    Windows taskbar identity, so octron_gui() must call setStyle() BEFORE
+    napari.Viewer(). This invariant has no runtime hook, so we assert it against
+    the source rather than relying on a comment.
+    """
+    main_py = Path(octron.__file__).parent / "main.py"
+    text = main_py.read_text(encoding="utf-8")
+
+    body = text[text.index("def octron_gui"):]
+    end = body.find("\nif __name__")
+    if end != -1:
+        body = body[:end]
+
+    assert "setStyle" in body and "napari.Viewer(" in body
+    assert body.index("setStyle") < body.index("napari.Viewer("), (
+        "octron_gui() must apply app.setStyle() before creating the napari "
+        "window, otherwise the window's Windows taskbar icon is lost."
+    )
+    # The window must be built hidden and given its taskbar identity before show.
+    assert "napari.Viewer(show=False)" in body
+    assert body.index("set_windows_taskbar_app_id") < body.index(".window.show()")


### PR DESCRIPTION
## Problem

Launching the GUI (`octron gui`) showed a generic `python.exe` icon on the Windows taskbar instead of the napari logo.

## Root causes (all needed fixing)

1. **`app.setStyle("Fusion")` ran *after* `napari.Viewer()`.** Re-polishing the Qt application style after a window is shown destroys that window's Windows taskbar identity → generic icon. It's now applied before any window is created (still global, so the ToolBox widget gets it).
2. **The window is now built hidden** (`napari.Viewer(show=False)`) so its taskbar identity is set before it's first shown — Windows binds a button's group/icon at show time.
3. **The napari OpenGL window doesn't reliably surface its Qt icon to the taskbar**, and it shares the process-wide AppUserModelID with Qt/vispy's hidden helper windows (→ collapsed into a generic shared group). While hidden it now gets: its own per-window AppUserModelID, a `RelaunchIconResource` pointing at napari's bundled `icon.ico`, and a forced native icon via `WM_SETICON`. All three are required.

All Windows-specific work is a no-op off Windows and swallows every error, so it can never break GUI startup.

## Refactor + tests

- Helper extracted to `octron/_taskbar.py` (pure ctypes, no torch/Qt/napari imports → cheap to import and test).
- `tests/test_taskbar.py`: COM round-trip (set per-window id + `.ico`, read both back, in an isolated subprocess so a `QApplication` can't hang pytest), the "never breaks startup" contract, and a source-level guard that `setStyle()` precedes window creation (the exact regression).

## Not covered

Whether the taskbar actually *renders* the logo is Windows shell behavior with no headless API to assert — verified manually. The tests lock down the mechanics underneath it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)